### PR TITLE
Add REST Task examples to the DIS Samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Reference Architecture
 
 This Terraform code creates a workspace in a defined VCN subnet, and applied all the necessary policies for the execution against the data assets for OCI Object Store and Oracle ADW. The Terraform application also uploads all the DIS Templates tasks, making the workspace readily available.
+
 ## Architecture Diagram 
 
 ![](./images/DIS-Reference-Architecture.png)

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -1,0 +1,92 @@
+# OCI Data Integration Common Tasks
+
+## Prerequisites
+You should have an OCI Data Integration workspace created and also a project within the workspace. You will need these to create the tasks below.
+
+## Setup
+Define the following environment variables and then execute the script to create the tasks in OCI DI.  Get the project key and the workspace and the region and set;
+```
+export PROJECTKEY=
+export WORKSPACE_ID=
+export REGION=us-ashburn-1
+```
+
+## Install via Script and OCI CLI
+install.sh
+
+## Install via Python and OCI Python SDK
+python3 install.py workspaceid prokectkey us-ashburn-1
+
+## Permissions
+
+The theme for all of these permissions is to allow the disworkspace resource permission to perform the APIs concerned. The tasks have been defined using workspace resource BUT REST tasks can be defined to use workspace or application resource, application resource will give a tighter control. The example permissions can be further refined for example the specific operation can be added.
+
+### Cloud Agent (OCI Compute) tasks
+```
+allow any-user to manage instance-agent-command-family in compartment <compartment-name> where ALL {request.principal.type='disworkspace’,request.principal.id='<workspace_ocid>’}
+allow any-user to manage instance-agent-command-execution-family in compartment <compartment-name> where ALL {request.principal.type='disworkspace’,request.principal.id='<workspace_ocid>’}
+```
+
+### Container Instance tasks
+```
+allow any-user to manage compute-container-family in compartment yourcompartment where ALL {request.principal.type = 'disworkspace'}
+```
+
+### Data Science tasks
+```
+allow any-user to manage data-science-family in compartment yourcompartment where ANY {request.principal.type = 'disworkspace'}	
+```
+
+### Object Storage tasks
+```
+allow any-user to manage object-family in compartment yourcompartment where ANY {request.principal.type = 'disworkspace'}	
+```
+
+### AI Speech tasks
+```
+allow any-user to manage ai-service-speech-family in compartment yourcompartment where ALL {request.principal.type = 'disworkspace'}
+```
+
+### AI Vision tasks
+```
+allow any-user to manage ai-service-vision-family in compartment yourcompartment where ALL {request.principal.type = 'disworkspace'}
+```
+
+### AI Speech tasks
+```
+allow any-user to manage ai-service-speech-family in compartment yourcompartment where ALL {request.principal.type = 'disworkspace'}
+```
+
+### AI Document tasks
+```
+allow any-user to manage ai-service-document-family in compartment yourcompartment where ALL {request.principal.type = 'disworkspace'}
+```
+
+### NoSQL tasks
+```
+allow any-user to manage nosql-family in compartment yourcompartment where ALL {request.principal.type = 'disworkspace'}
+```
+
+### Monitoring tasks
+```
+allow any-user to read metrics in compartment yourcompartment where ALL {request.principal.type = 'disworkspace'}
+```
+
+### Notification tasks
+```
+allow any-user to use ons-topics in compartment yourcompartment where ALL {request.principal.type = 'disworkspace'}
+```
+
+### Dataflow tasks
+```
+allow any-user to manage dataflow-run in compartment yourcompartment where ALL {request.principal.type = 'disworkspace'}
+```
+
+### Data Integration tasks
+```
+allow any-user to use dis-workspaces in compartment yourcompartment where ALL {request.principal.type = 'disworkspace'}
+```
+
+### Generic REST executor
+
+Whatever permissions are needed for the service you use you will need to add just like above using resource principal.

--- a/tasks/install.py
+++ b/tasks/install.py
@@ -1,0 +1,38 @@
+import oci
+import json
+import requests
+import sys
+import glob
+import os
+from oci.signer import Signer
+
+config = oci.config.from_file('~/.oci/config')
+# For raw-requests, get the signer auth
+auth = Signer(
+    tenancy=config['tenancy'],
+    user=config['user'],
+    fingerprint=config['fingerprint'],
+    private_key_file_location=config['key_file']
+)
+
+data_integration_client = oci.data_integration.DataIntegrationClient(config)
+
+workspaceID = sys.argv [1]
+projectKey = sys.argv[2]
+region = sys.argv[3]
+
+url = 'https://dataintegration.' + region + '.oci.oraclecloud.com/20200430/workspaces/' + workspaceID + '/tasks'
+
+path = "src/tasks/**"
+
+for path in glob.glob(path, recursive=True):
+ if path.endswith('.json'):
+    print(path)
+    with open(path, 'r') as file:
+      filedata = file.read()
+      filedata = filedata.replace('{{PROJECT_KEY}}', projectKey)
+      payload=json.loads(filedata)
+      response = requests.post(url, auth=auth, json=payload)
+      print('Request response: ')
+      print(json.loads(response.content.decode('utf8')))
+

--- a/tasks/install.sh
+++ b/tasks/install.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Enter the project key and the workspace
+#export PROJECTKEY=
+#export WORKSPACE_ID=
+#export REGION=
+
+for FILE in src/tasks/*/*; do 
+  echo $FILE
+  rslt=$(cat $FILE | sed 's/{{PROJECT_KEY}}/'$PROJECTKEY'/g');
+  oci raw-request --http-method POST --target-uri https://dataintegration.${REGION}.oci.oraclecloud.com/20200430/workspaces/$WORKSPACE_ID/tasks --request-body "$rslt";
+done

--- a/tasks/src/tasks/aidocument/aidocumenttable.json
+++ b/tasks/src/tasks/aidocument/aidocumenttable.json
@@ -1,0 +1,257 @@
+{
+  "modelType": "REST_TASK",
+  "name": "AI Document Table Extraction Task",
+  "description": "Table extraction using Document Understanding API.\nhttps://docs.oracle.com/en-us/iaas/api/#/en/document-understanding/20221109/ProcessorJob/CreateProcessorJob",
+  "identifier": "AIDOCUMENTTABLEEXTRACTIONTASK",
+  "parameters": [
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL),Termination API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Termination API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Termination API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Termination API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Termination API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Termination API Config: (Request URL),Polling API Config: (Request URL)"
+          }
+        }
+      },
+      "defaultValue": "us-ashburn-1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "REGION",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "defaultValue": "namespacename",
+      "isInput": true,
+      "isOutput": false,
+      "name": "OUTPUT_NAMESPACE",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "defaultValue": "templatedemo",
+      "isInput": true,
+      "isOutput": false,
+      "name": "OUTPUT_BUCKET",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "defaultValue": "visionout",
+      "isInput": true,
+      "isOutput": false,
+      "name": "OUTPUT_PREFIX",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "defaultValue": "compartmentid",
+      "isInput": true,
+      "isOutput": false,
+      "name": "COMPARTMENT",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "defaultValue": "TableDetection",
+      "isInput": true,
+      "isOutput": false,
+      "name": "JOB_NAME",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "[{\"bucketName\":\"example\",\"namespaceName\":\"idexample\",\"objectName\":\"document.txt\"}]",
+      "isInput": true,
+      "isOutput": false,
+      "name": "INPUT_DATA",
+      "typeName": "STRING"
+    }
+  ],
+  "opConfigValues": {
+    "configParamValues": {
+      "successCondition": {
+        "refValue": {
+          "modelType": "EXPRESSION",
+          "exprString": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS <= 300 AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) == 'SUCCEEDED'"
+          }
+        }
+      }
+  },
+  "executeRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "POST",
+    "requestHeaders": {
+      "Accept": "application/json",
+      "Content-Type": "application/json"
+    },
+    "configValues": {
+      "configParamValues": {
+        "requestPayload": {
+          "refValue": {
+            "modelType": "JSON_TEXT",
+            "encoded": false,
+            "configValues": {
+              "configParamValues": {
+                "dataParam": {
+                  "stringValue": "{\n    \"processorConfig\": {\n        \"processorType\": \"GENERAL\",\n        \"features\": [\n            {\n                \"featureType\": \"TABLE_EXTRACTION\"\n            }\n        ]\n    },\n    \"inputLocation\": {\n        \"sourceType\": \"OBJECT_STORAGE_LOCATIONS\",\n        \"objectLocations\": ${INPUT_DATA}\n    },\n    \"outputLocation\": {\n        \"bucketName\": \"${OUTPUT_BUCKET}\",\n        \"namespaceName\": \"${OUTPUT_NAMESPACE}\",\n        \"prefix\": \"${OUTPUT_PREFIX}\"\n    },\n    \"compartmentId\": \"${COMPARTMENT}\"\n}"
+                }
+              }
+            }
+          }
+        },
+        "requestURL": {
+          "stringValue": "https://document.aiservice.${REGION}.oci.oraclecloud.com/20221109/processorJobs"
+        }
+      }
+    }
+  },
+  "cancelRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "POST",
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "https://vision.aiservice.${REGION}.oci.oraclecloud.com/20220125/documentJobs/#{DOCUMENT_JOB_OCID}/actions/cancel"
+        }
+      }
+    }
+  },
+  "pollRestCallConfig": {
+    "modelType": "POLL_REST_CALL_CONFIG",
+    "methodType": "GET",
+    "configValues": {
+      "configParamValues": {
+        "pollCondition": {
+          "refValue": {
+            "modelType": "EXPRESSION",
+            "exprString": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'SUCCEEDED' AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'FAILED'"
+          }
+        },
+        "pollInterval": {
+          "objectValue": 60
+        },
+        "requestURL": {
+          "stringValue": "https://document.aiservice.${REGION}.oci.oraclecloud.com/20221109/processorJobs/#{DOCUMENT_JOB_OCID}"
+        },
+        "pollMaxDuration": {
+          "objectValue": 600
+        },
+        "pollMaxDurationUnit": {
+          "stringValue": "SECONDS"
+        },
+        "pollIntervalUnit": {
+          "stringValue": "SECONDS"
+        }
+      }
+    }
+  },
+  "typedExpressions": [
+    {
+      "modelType": "TYPED_EXPRESSION",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "expression": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.id') AS String)",
+      "name": "DOCUMENT_JOB_OCID"
+    }
+  ],
+  "apiCallMode": "ASYNC_GENERIC",
+  "authDetails": {
+    "modelType": "RESOURCE_PRINCIPAL_AUTH_DETAILS"
+  },
+  "authConfig": {
+    "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+    "resourcePrincipalSource": "WORKSPACE"
+  },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }
+}

--- a/tasks/src/tasks/aispeech/aispeech.json
+++ b/tasks/src/tasks/aispeech/aispeech.json
@@ -1,0 +1,261 @@
+{
+  "modelType": "REST_TASK",
+  "name": "AI Speech Task",
+  "description": "Analyze objects in OCI Object Storage and extract information from the speech documents.",
+  "identifier": "AISPEECHTASK",
+  "parameters": [
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Region name.",
+      "defaultValue": "us-ashburn-1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "REGION",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "[{\"type\":\"PROFANITY\",\"mode\":\"REMOVE\"}]",
+      "isInput": true,
+      "isOutput": false,
+      "name": "JOB_FILTERS",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Compartment id for job.",
+      "defaultValue": "compartmentid",
+      "isInput": true,
+      "isOutput": false,
+      "name": "COMPARTMENT_ID",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Display name for speech job.",
+      "defaultValue": "SpeechJob",
+      "isInput": true,
+      "isOutput": false,
+      "name": "DISPLAY_NAME",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Output namspace.",
+      "defaultValue": "namespacename",
+      "isInput": true,
+      "isOutput": false,
+      "name": "OUTPUT_NAMESPACE",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Output prefix for folder containing generated objects.",
+      "defaultValue": "speechout",
+      "isInput": true,
+      "isOutput": false,
+      "name": "OUTPUT_PREFIX",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Output bucket name.",
+      "defaultValue": "a_delta_archive",
+      "isInput": true,
+      "isOutput": false,
+      "name": "OUTPUT_BUCKET",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Input data, specify namespace, bucket name and object names.",
+      "defaultValue": "[{\"namespaceName\": \"namespacename\",\"bucketName\": \"a_delta_changes\",\"objectNames\": [\"the-poet.wav\"] } ]",
+      "isInput": true,
+      "isOutput": false,
+      "name": "INPUT_DATA",
+      "typeName": "VARCHAR"
+    }
+  ],
+  "opConfigValues": {
+    "configParamValues": {
+      "successCondition": {
+        "refValue": {
+          "modelType": "EXPRESSION",
+          "exprString": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS <= 300 AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) == 'SUCCEEDED'"
+        }
+      }
+    }
+  },
+  "executeRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "POST",
+    "requestHeaders": {
+      "Content-Type": "application/json"
+    },
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "https://speech.aiservice.${REGION}.oci.oraclecloud.com/20220101/transcriptionJobs"
+        },
+        "requestPayload": {
+          "refValue": {
+            "modelType": "JSON_TEXT",
+            "encoded": false,
+            "configValues": {
+              "configParamValues": {
+                "dataParam": {
+                  "stringValue": "{  \"normalization\": {\"filters\": ${JOB_FILTERS},    \"isPunctuationEnabled\": true  },  \"compartmentId\": \"${COMPARTMENT_ID}\",  \"displayName\": \"${DISPLAY_NAME}\",  \"freeformTags\": {},  \"definedTags\": {},  \"modelDetails\": {    \"domain\": \"GENERIC\",    \"languageCode\": \"en-US\"  },  \"inputLocation\": {    \"locationType\": \"OBJECT_LIST_INLINE_INPUT_LOCATION\",    \"objectLocations\": ${INPUT_DATA}  },  \"outputLocation\": {    \"namespaceName\": \"${OUTPUT_NAMESPACE}\",    \"bucketName\": \"${OUTPUT_BUCKET}\",    \"prefix\": \"${OUTPUT_PREFIX}\"  },  \"additionalTranscriptionFormats\": null}"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "cancelRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "DELETE"
+  },
+  "pollRestCallConfig": {
+    "modelType": "POLL_REST_CALL_CONFIG",
+    "methodType": "GET",
+    "configValues": {
+      "configParamValues": {
+        "pollMaxDuration": {
+          "objectValue": 600
+        },
+        "pollMaxDurationUnit": {
+          "stringValue": "SECONDS"
+        },
+        "pollInterval": {
+          "objectValue": 60
+        },
+        "pollIntervalUnit": {
+          "stringValue": "SECONDS"
+        },
+        "requestURL": {
+          "stringValue": "https://speech.aiservice.${REGION}.oci.oraclecloud.com/20220101/transcriptionJobs/#{SPEECH_JOB_OCID}"
+        },
+        "pollCondition": {
+          "refValue": {
+            "modelType": "EXPRESSION",
+            "exprString": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'SUCCEEDED' AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'FAILED'"
+          }
+        }
+      }
+    }
+  },
+  "typedExpressions": [
+    {
+      "modelType": "TYPED_EXPRESSION",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 2000
+          }
+        }
+      },
+      "expression": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.id') AS String)",
+      "name": "SPEECH_JOB_OCID"
+    }
+  ],
+  "apiCallMode": "ASYNC_GENERIC",
+  "authConfig": {
+    "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+    "resourcePrincipalSource": "WORKSPACE"
+  },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }
+}

--- a/tasks/src/tasks/aivision/aiimageclassification.json
+++ b/tasks/src/tasks/aivision/aiimageclassification.json
@@ -1,0 +1,254 @@
+{
+  "modelType": "REST_TASK",
+  "name": "AI Image Classification Task",
+  "identifier": "AIIMAGECLASSIFICATIONTASK",
+  "parameters": [
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL),Termination API Config: (Request URL),Polling API Config: (Request URL)"
+          }
+        }
+      },
+      "defaultValue": "us-ashburn-1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "REGION",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "defaultValue": "namespacename",
+      "isInput": true,
+      "isOutput": false,
+      "name": "OUTPUT_NAMESPACE",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "defaultValue": "templatedemo",
+      "isInput": true,
+      "isOutput": false,
+      "name": "OUTPUT_BUCKET",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "defaultValue": "visionout",
+      "isInput": true,
+      "isOutput": false,
+      "name": "OUTPUT_PREFIX",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "defaultValue": "compartmentid",
+      "isInput": true,
+      "isOutput": false,
+      "name": "COMPARTMENT",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "defaultValue": "ImageClassification",
+      "isInput": true,
+      "isOutput": false,
+      "name": "JOB_NAME",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "defaultValue": "[ { \"bucketName\": \"a_delta_archive\", \"namespaceName\": \"namespacename\", \"objectName\": \"powerlines.png\" } ]",
+      "isInput": true,
+      "isOutput": false,
+      "name": "INPUT_DATA",
+      "typeName": "STRING"
+    }
+  ],
+  "opConfigValues": {
+    "configParamValues": {
+      "successCondition": {
+        "stringValue": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS <= 300 AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) == 'SUCCEEDED'"
+      }
+    }
+  },
+  "executeRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "POST",
+    "requestHeaders": {
+      "Accept": "application/json",
+      "Content-Type": "application/json"
+    },
+    "configValues": {
+      "configParamValues": {
+        "requestPayload": {
+          "refValue": {
+            "modelType": "JSON_TEXT",
+            "encoded": false,
+            "configValues": {
+              "configParamValues": {
+                "dataParam": {
+                  "stringValue": "{\"features\":[{\"featureType\":\"IMAGE_CLASSIFICATION\"}], \"inputLocation\": { \"sourceType\": \"OBJECT_LIST_INLINE_INPUT_LOCATION\", \"objectLocations\": ${INPUT_DATA} }, \"outputLocation\": { \"bucketName\": \"${OUTPUT_BUCKET}\", \"namespaceName\": \"${OUTPUT_NAMESPACE}\", \"prefix\": \"${OUTPUT_PREFIX}\" }, \"compartmentId\": \"${COMPARTMENT}\", \"displayName\": \"${JOB_NAME}\", \"isZipOutputEnabled\": false }"
+                }
+              }
+            }
+          }
+        },
+        "requestURL": {
+          "stringValue": "https://vision.aiservice.${REGION}.oci.oraclecloud.com/20220125/imageJobs"
+        }
+      }
+    }
+  },
+  "cancelRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "POST",
+    "requestHeaders": {},
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "https://vision.aiservice.${REGION}.oci.oraclecloud.com/20220125/imageJobs/#{IMAGE_JOB_OCID}/actions/cancel"
+        }
+      }
+    }
+  },
+  "pollRestCallConfig": {
+    "modelType": "POLL_REST_CALL_CONFIG",
+    "methodType": "GET",
+    "configValues": {
+      "configParamValues": {
+        "pollCondition": {
+          "stringValue": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'SUCCEEDED'"
+        },
+        "pollInterval": {
+          "objectValue": 60
+        },
+        "requestURL": {
+          "stringValue": "https://vision.aiservice.${REGION}.oci.oraclecloud.com/20220125/imageJobs/#{IMAGE_JOB_OCID}"
+        },
+        "pollMaxDuration": {
+          "objectValue": 120
+        },
+        "pollMaxDurationUnit": {
+          "stringValue": "SECONDS"
+        },
+        "pollIntervalUnit": {
+          "stringValue": "SECONDS"
+        }
+      }
+    }
+  },
+  "typedExpressions": [
+    {
+      "modelType": "TYPED_EXPRESSION",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "expression": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.id') AS String)",
+      "name": "IMAGE_JOB_OCID"
+    }
+  ],
+  "apiCallMode": "ASYNC_GENERIC",
+  "authDetails": {
+    "modelType": "RESOURCE_PRINCIPAL_AUTH_DETAILS"
+  },
+  "authConfig": {
+    "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+    "resourcePrincipalSource": "WORKSPACE"
+  },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }
+}

--- a/tasks/src/tasks/aivision/aiimageobjectdetection.json
+++ b/tasks/src/tasks/aivision/aiimageobjectdetection.json
@@ -1,0 +1,252 @@
+{
+  "modelType": "REST_TASK",
+  "name": "AI Image Object Detection Task",
+  "identifier": "AIIMAGEOBJECTDETECTIONTASK",
+  "parameters": [
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL),Termination API Config: (Request URL),Polling API Config: (Request URL)"
+          }
+        }
+      },
+      "defaultValue": "us-ashburn-1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "REGION",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "defaultValue": "namespacename",
+      "isInput": true,
+      "isOutput": false,
+      "name": "OUTPUT_NAMESPACE",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "defaultValue": "templatedemo",
+      "isInput": true,
+      "isOutput": false,
+      "name": "OUTPUT_BUCKET",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "defaultValue": "visionout",
+      "isInput": true,
+      "isOutput": false,
+      "name": "OUTPUT_PREFIX",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "defaultValue": "compartmentid",
+      "isInput": true,
+      "isOutput": false,
+      "name": "COMPARTMENT",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "defaultValue": "ObjectDetection",
+      "isInput": true,
+      "isOutput": false,
+      "name": "JOB_NAME",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "defaultValue": "[ { \"bucketName\": \"a_delta_archive\", \"namespaceName\": \"namespacename\", \"objectName\": \"powerlines.png\" } ]",
+      "isInput": true,
+      "isOutput": false,
+      "name": "INPUT_DATA",
+      "typeName": "STRING"
+    }
+  ],
+  "opConfigValues": {
+    "configParamValues": {
+      "successCondition": {
+        "stringValue": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS <= 300 AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) == 'SUCCEEDED'"
+      }
+    }
+  },
+  "executeRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "POST",
+    "requestHeaders": {
+      "Accept": "application/json",
+      "Content-Type": "application/json"
+    },
+    "configValues": {
+      "configParamValues": {
+        "requestPayload": {
+          "refValue": {
+            "modelType": "JSON_TEXT",
+            "encoded": false,
+            "configValues": {
+              "configParamValues": {
+                "dataParam": {
+                  "stringValue": "{\"features\":[{\"featureType\":\"OBJECT_DETECTION\", \"maxResult\":50}], \"inputLocation\": { \"sourceType\": \"OBJECT_LIST_INLINE_INPUT_LOCATION\", \"objectLocations\": ${INPUT_DATA} }, \"outputLocation\": { \"bucketName\": \"${OUTPUT_BUCKET}\", \"namespaceName\": \"${OUTPUT_NAMESPACE}\", \"prefix\": \"${OUTPUT_PREFIX}\" }, \"compartmentId\": \"${COMPARTMENT}\", \"displayName\": \"${JOB_NAME}\", \"isZipOutputEnabled\": false }"
+                }
+              }
+            }
+          }
+        },
+        "requestURL": {
+          "stringValue": "https://vision.aiservice.${REGION}.oci.oraclecloud.com/20220125/imageJobs"
+        }
+      }
+    }
+  },
+  "cancelRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "POST",
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "https://vision.aiservice.${REGION}.oci.oraclecloud.com/20220125/imageJobs/#{IMAGE_JOB_OCID}/actions/cancel"
+        }
+      }
+    }
+  },
+  "pollRestCallConfig": {
+    "modelType": "POLL_REST_CALL_CONFIG",
+    "methodType": "GET",
+    "configValues": {
+      "configParamValues": {
+        "pollCondition": {
+          "stringValue": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'SUCCEEDED'"
+        },
+        "pollInterval": {
+          "objectValue": 60
+        },
+        "requestURL": {
+          "stringValue": "https://vision.aiservice.${REGION}.oci.oraclecloud.com/20220125/imageJobs/#{IMAGE_JOB_OCID}"
+        },
+        "pollMaxDuration": {
+          "objectValue": 120
+        },
+        "pollMaxDurationUnit": {
+          "stringValue": "SECONDS"
+        },
+        "pollIntervalUnit": {
+          "stringValue": "SECONDS"
+        }
+      }
+    }
+  },
+  "typedExpressions": [
+    {
+      "modelType": "TYPED_EXPRESSION",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "expression": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.id') AS String)",
+      "name": "IMAGE_JOB_OCID"
+    }
+  ],
+  "apiCallMode": "ASYNC_GENERIC",
+  "authDetails": {
+    "modelType": "RESOURCE_PRINCIPAL_AUTH_DETAILS"
+  },
+  "authConfig": {
+    "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+    "resourcePrincipalSource": "WORKSPACE"
+  },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }
+}

--- a/tasks/src/tasks/aivision/aiimagetabledetection.json
+++ b/tasks/src/tasks/aivision/aiimagetabledetection.json
@@ -1,0 +1,253 @@
+{
+  "modelType": "REST_TASK",
+  "name": "AI Image Table Detection Task",
+  "identifier": "AIIMAGETABLEDETECTIONTASK",
+  "parameters": [
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL),Termination API Config: (Request URL),Polling API Config: (Request URL)"
+          }
+        }
+      },
+      "defaultValue": "us-ashburn-1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "REGION",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "defaultValue": "namespacename",
+      "isInput": true,
+      "isOutput": false,
+      "name": "OUTPUT_NAMESPACE",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "defaultValue": "templatedemo",
+      "isInput": true,
+      "isOutput": false,
+      "name": "OUTPUT_BUCKET",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "defaultValue": "visionout",
+      "isInput": true,
+      "isOutput": false,
+      "name": "OUTPUT_PREFIX",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "defaultValue": "compartmentid",
+      "isInput": true,
+      "isOutput": false,
+      "name": "COMPARTMENT",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        },
+        "parentRef": {}
+      },
+      "defaultValue": "TableDetection",
+      "isInput": true,
+      "isOutput": false,
+      "name": "JOB_NAME",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "defaultValue": "[ { \"bucketName\": \"a_delta_archive\", \"namespaceName\": \"namespacename\", \"objectName\": \"quarter_numbers_abc.pdf\" } ]",
+      "isInput": true,
+      "isOutput": false,
+      "name": "INPUT_DATA",
+      "typeName": "STRING"
+    }
+  ],
+  "opConfigValues": {
+    "configParamValues": {
+      "successCondition": {
+        "stringValue": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS <= 300 AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) == 'SUCCEEDED'"
+      }
+    }
+  },
+  "executeRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "POST",
+    "requestHeaders": {
+      "Accept": "application/json",
+      "Content-Type": "application/json"
+    },
+    "configValues": {
+      "configParamValues": {
+        "requestPayload": {
+          "refValue": {
+            "modelType": "JSON_TEXT",
+            "encoded": false,
+            "configValues": {
+              "configParamValues": {
+                "dataParam": {
+                  "stringValue": "{\"features\":[{\"featureType\":\"TABLE_DETECTION\"}], \"inputLocation\": { \"sourceType\": \"OBJECT_LIST_INLINE_INPUT_LOCATION\", \"objectLocations\": ${INPUT_DATA} }, \"outputLocation\": { \"bucketName\": \"${OUTPUT_BUCKET}\", \"namespaceName\": \"${OUTPUT_NAMESPACE}\", \"prefix\": \"${OUTPUT_PREFIX}\" }, \"compartmentId\": \"${COMPARTMENT}\", \"displayName\": \"${JOB_NAME}\", \"isZipOutputEnabled\": false }"
+                }
+              }
+            }
+          }
+        },
+        "requestURL": {
+          "stringValue": "https://vision.aiservice.${REGION}.oci.oraclecloud.com/20220125/documentJobs"
+        }
+      }
+    }
+  },
+  "cancelRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "POST",
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "https://vision.aiservice.${REGION}.oci.oraclecloud.com/20220125/documentJobs/#{DOCUMENT_JOB_OCID}/actions/cancel"
+        }
+      }
+    }
+  },
+  "pollRestCallConfig": {
+    "modelType": "POLL_REST_CALL_CONFIG",
+    "methodType": "GET",
+    "configValues": {
+      "configParamValues": {
+        "pollCondition": {
+          "stringValue": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'SUCCEEDED'"
+        },
+        "pollInterval": {
+          "objectValue": 60
+        },
+        "requestURL": {
+          "stringValue": "https://vision.aiservice.${REGION}.oci.oraclecloud.com/20220125/documentJobs/#{DOCUMENT_JOB_OCID}"
+        },
+        "pollMaxDuration": {
+          "objectValue": 120
+        },
+        "pollMaxDurationUnit": {
+          "stringValue": "SECONDS"
+        },
+        "pollIntervalUnit": {
+          "stringValue": "SECONDS"
+        }
+      }
+    }
+  },
+  "typedExpressions": [
+    {
+      "modelType": "TYPED_EXPRESSION",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "expression": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.id') AS String)",
+      "name": "DOCUMENT_JOB_OCID"
+    }
+  ],
+  "apiCallMode": "ASYNC_GENERIC",
+  "authDetails": {
+    "modelType": "RESOURCE_PRINCIPAL_AUTH_DETAILS"
+  },
+  "authConfig": {
+    "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+    "resourcePrincipalSource": "WORKSPACE"
+  },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }
+}

--- a/tasks/src/tasks/aivision/aiimagetextdetection.json
+++ b/tasks/src/tasks/aivision/aiimagetextdetection.json
@@ -1,0 +1,252 @@
+{
+  "modelType": "REST_TASK",
+  "name": "AI Image Text Detection Task",
+  "identifier": "AIIMAGETEXTDETECTIONTASK",
+  "parameters": [
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL),Termination API Config: (Request URL),Polling API Config: (Request URL)"
+          }
+        }
+      },
+      "defaultValue": "us-ashburn-1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "REGION",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        },
+        "parentRef": {}
+      },
+      "defaultValue": "namespacename",
+      "isInput": true,
+      "isOutput": false,
+      "name": "OUTPUT_NAMESPACE",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "defaultValue": "templatedemo",
+      "isInput": true,
+      "isOutput": false,
+      "name": "OUTPUT_BUCKET",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "defaultValue": "visionout",
+      "isInput": true,
+      "isOutput": false,
+      "name": "OUTPUT_PREFIX",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "defaultValue": "compartmentid",
+      "isInput": true,
+      "isOutput": false,
+      "name": "COMPARTMENT",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          }
+        },
+        "parentRef": {}
+      },
+      "defaultValue": "TextDetection",
+      "isInput": true,
+      "isOutput": false,
+      "name": "JOB_NAME",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "defaultValue": "[ { \"bucketName\": \"a_delta_archive\", \"namespaceName\": \"namespacename\", \"objectName\": \"powerlines.png\" } ]",
+      "isInput": true,
+      "isOutput": false,
+      "name": "INPUT_DATA",
+      "typeName": "STRING"
+    }
+  ],
+  "opConfigValues": {
+    "configParamValues": {
+      "successCondition": {
+        "stringValue": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS <= 300 AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) == 'SUCCEEDED'"
+      }
+    }
+  },
+  "executeRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "POST",
+    "requestHeaders": {
+      "Accept": "application/json",
+      "Content-Type": "application/json"
+    },
+    "configValues": {
+      "configParamValues": {
+        "requestPayload": {
+          "refValue": {
+            "modelType": "JSON_TEXT",
+            "encoded": false,
+            "configValues": {
+              "configParamValues": {
+                "dataParam": {
+                  "stringValue": "{\"features\":[{\"featureType\":\"TEXT_DETECTION\"}], \"inputLocation\": { \"sourceType\": \"OBJECT_LIST_INLINE_INPUT_LOCATION\", \"objectLocations\": ${INPUT_DATA} }, \"outputLocation\": { \"bucketName\": \"${OUTPUT_BUCKET}\", \"namespaceName\": \"${OUTPUT_NAMESPACE}\", \"prefix\": \"${OUTPUT_PREFIX}\" }, \"compartmentId\": \"${COMPARTMENT}\", \"displayName\": \"{JOB_NAME}\", \"isZipOutputEnabled\": false }"
+                }
+              }
+            }
+          }
+        },
+        "requestURL": {
+          "stringValue": "https://vision.aiservice.${REGION}.oci.oraclecloud.com/20220125/imageJobs"
+        }
+      }
+    }
+  },
+  "cancelRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "POST",
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "https://vision.aiservice.${REGION}.oci.oraclecloud.com/20220125/imageJobs/#{IMAGE_JOB_OCID}/actions/cancel"
+        }
+      }
+    }
+  },
+  "pollRestCallConfig": {
+    "modelType": "POLL_REST_CALL_CONFIG",
+    "methodType": "GET",
+    "requestHeaders": {},
+    "configValues": {
+      "configParamValues": {
+        "pollCondition": {
+          "stringValue": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'SUCCEEDED'"
+        },
+        "pollInterval": {
+          "objectValue": 60
+        },
+        "requestURL": {
+          "stringValue": "https://vision.aiservice.${REGION}.oci.oraclecloud.com/20220125/imageJobs/#{IMAGE_JOB_OCID}"
+        },
+        "pollMaxDuration": {
+          "objectValue": 120
+        },
+        "pollMaxDurationUnit": {
+          "stringValue": "SECONDS"
+        },
+        "pollIntervalUnit": {
+          "stringValue": "SECONDS"
+        }
+      }
+    }
+  },
+  "typedExpressions": [
+    {
+      "modelType": "TYPED_EXPRESSION",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "expression": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.id') AS String)",
+      "name": "IMAGE_JOB_OCID"
+    }
+  ],
+  "apiCallMode": "ASYNC_GENERIC",
+  "authDetails": {
+    "modelType": "RESOURCE_PRINCIPAL_AUTH_DETAILS"
+  },
+  "authConfig": {
+    "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+    "resourcePrincipalSource": "WORKSPACE"
+  },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }
+}

--- a/tasks/src/tasks/compute/cloudagentcmd.json
+++ b/tasks/src/tasks/compute/cloudagentcmd.json
@@ -1,0 +1,210 @@
+{
+  "modelType": "REST_TASK",
+  "name": "ExecuteCmdCloudAgentTask",
+  "identifier": "EXECUTECMDCLOUDAGENTTASK",
+  "parameters": [
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload),Polling API Config: (Request URL), Execute API Config: (Request Payload),Polling API Config: (Request URL), Execute API Config: (Request Payload),Polling API Config: (Request URL), Execute API Config: (Request Payload),Polling API Config: (Request URL), Execute API Config: (Request Payload),Polling API Config: (Request URL), Execute API Config: (Request Payload),Polling API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Compute instance id",
+      "defaultValue": "instanceid",
+      "isInput": true,
+      "isOutput": false,
+      "name": "INSTANCE_ID",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "compartmentid",
+      "isInput": true,
+      "isOutput": false,
+      "name": "COMPARTMENT_ID",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Shell script text",
+      "defaultValue": "xxx",
+      "isInput": true,
+      "isOutput": false,
+      "name": "SCRIPT_TEXT",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL),Termination API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Termination API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Termination API Config: (Request URL),Polling API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "OCI region for endpoint.",
+      "defaultValue": "us-ashburn-1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "REGION",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload), Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Command name.",
+      "defaultValue": "export_to_object_storage",
+      "isInput": true,
+      "isOutput": false,
+      "name": "COMMAND_NAME",
+      "typeName": "VARCHAR"
+    }
+  ],
+  "opConfigValues": {
+    "configParamValues": {
+      "successCondition": {
+        "refValue": {
+          "modelType": "EXPRESSION",
+          "exprString": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS <= 300 AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) == 'SUCCEEDED'"
+        }
+      }
+    },
+    "parentRef": {}
+  },
+  "executeRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "POST",
+    "requestHeaders": {
+      "Content-Type": "application/json",
+      "Accept": "application/json"
+    },
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "https://iaas.${REGION}.oraclecloud.com/20180530/instanceAgentCommands"
+        },
+        "requestPayload": {
+          "refValue": {
+            "modelType": "JSON_TEXT",
+            "encoded": false,
+            "configValues": {
+              "configParamValues": {
+                "dataParam": {
+                  "stringValue": "{  \"compartmentId\": \"${COMPARTMENT_ID}\", \"executionTimeOutInSeconds\": 3600,  \"displayName\": \"${COMMAND_NAME}\",  \"target\": {    \"instanceId\": \"${INSTANCE_ID}\"  },  \"content\": {    \"source\": {      \"sourceType\": \"TEXT\",     \"text\": \"${SCRIPT_TEXT}\"    },    \"output\": {      \"outputType\": \"TEXT\"    }  }}"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "cancelRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "DELETE",
+    "requestHeaders": {},
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "https://iaas.${REGION}.oraclecloud.com/20180530/instanceAgentCommands/#{COMMAND_ID}"
+        }
+      }
+    }
+  },
+  "pollRestCallConfig": {
+    "modelType": "POLL_REST_CALL_CONFIG",
+    "methodType": "GET",
+    "configValues": {
+      "configParamValues": {
+        "pollMaxDuration": {
+          "objectValue": 300
+        },
+        "pollMaxDurationUnit": {
+          "stringValue": "SECONDS"
+        },
+        "pollInterval": {
+          "objectValue": 60
+        },
+        "pollIntervalUnit": {
+          "stringValue": "SECONDS"
+        },
+        "requestURL": {
+          "stringValue": "https://iaas.${REGION}.oraclecloud.com/20180530/instanceAgentCommands/#{COMMAND_ID}/status?instanceId=${INSTANCE_ID}"
+        },
+        "pollCondition": {
+          "refValue": {
+            "modelType": "EXPRESSION",
+            "exprString": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'SUCCEEDED' AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'FAILED'"
+          }
+        }
+      }
+    }
+  },
+  "typedExpressions": [
+    {
+      "modelType": "TYPED_EXPRESSION",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 2000
+          }
+        }
+      },
+      "expression": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.id') AS String)",
+      "name": "COMMAND_ID"
+    }
+  ],
+  "apiCallMode": "ASYNC_GENERIC",
+  "authConfig": {
+    "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+    "resourcePrincipalSource": "WORKSPACE"
+  },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }
+}

--- a/tasks/src/tasks/compute/cloudagentcmdos.json
+++ b/tasks/src/tasks/compute/cloudagentcmdos.json
@@ -1,0 +1,269 @@
+{
+  "modelType": "REST_TASK",
+  "name": "ExecuteCmdCloudAgentLogTask",
+  "description": "Execute command on Cloud Agent in OCI Compute and Log result in OCI Object Storage.",
+  "identifier": "EXECUTECMDCLOUDAGENTLOGTASK",
+  "parameters": [
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload),Polling API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Compute instance id run run on Cloud Agent.",
+      "defaultValue": "instanceid",
+      "isInput": true,
+      "isOutput": false,
+      "name": "INSTANCE_ID",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Compartment Id to create the command within.",
+      "defaultValue": "compartmentid",
+      "isInput": true,
+      "isOutput": false,
+      "name": "COMPARTMENT_ID",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Shell script string.",
+      "defaultValue": "echo 'Hello World'",
+      "isInput": true,
+      "isOutput": false,
+      "name": "SCRIPT_TEXT",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL),Termination API Config: (Request URL),Polling API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "OCI region for endpoint.",
+      "defaultValue": "us-ashburn-1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "REGION",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Command name.",
+      "defaultValue": "Cloud agent demo",
+      "isInput": true,
+      "isOutput": false,
+      "name": "COMMAND_NAME",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "OCI Object Storage Namespace Name",
+      "defaultValue": "yournamespace",
+      "isInput": true,
+      "isOutput": false,
+      "name": "NAMESPACE_NAME",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "OCI Object Storage bucket name for log.",
+      "defaultValue": "yourbucketname",
+      "isInput": true,
+      "isOutput": false,
+      "name": "BUCKET_NAME",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "OCI Object Storage log name",
+      "defaultValue": "yourobjectname",
+      "isInput": true,
+      "isOutput": false,
+      "name": "OBJECT_NAME",
+      "typeName": "VARCHAR"
+    }
+  ],
+  "opConfigValues": {
+    "configParamValues": {
+      "successCondition": {
+        "refValue": {
+          "modelType": "EXPRESSION",
+          "exprString": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS <= 300 AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) == 'SUCCEEDED'"
+        }
+      }
+    }
+  },
+  "executeRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "POST",
+    "requestHeaders": {
+      "Content-Type": "application/json",
+      "Accept": "application/json"
+    },
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "https://iaas.${REGION}.oraclecloud.com/20180530/instanceAgentCommands"
+        },
+        "requestPayload": {
+          "refValue": {
+            "modelType": "JSON_TEXT",
+            "encoded": false,
+            "configValues": {
+              "configParamValues": {
+                "dataParam": {
+                  "stringValue": "{  \"compartmentId\": \"${COMPARTMENT_ID}\", \"executionTimeOutInSeconds\": 3600,  \"displayName\": \"${COMMAND_NAME}\",  \"target\": {    \"instanceId\": \"${INSTANCE_ID}\"  },  \"content\": {    \"source\": {      \"sourceType\": \"TEXT\",     \"text\": \"${SCRIPT_TEXT}\"    },    \"output\": {      \"outputType\": \"OBJECT_STORAGE_TUPLE\", \"namespaceName\": \"${NAMESPACE_NAME}\", \"bucketName\": \"${BUCKET_NAME}\", \"objectName\": \"${OBJECT_NAME}\"    }  }}"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "cancelRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "DELETE",
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "https://iaas.${REGION}.oraclecloud.com/20180530/instanceAgentCommands/#{COMMAND_ID}"
+        }
+      }
+    }
+  },
+  "pollRestCallConfig": {
+    "modelType": "POLL_REST_CALL_CONFIG",
+    "methodType": "GET",
+    "configValues": {
+      "configParamValues": {
+        "pollMaxDuration": {
+          "objectValue": 300
+        },
+        "pollMaxDurationUnit": {
+          "stringValue": "SECONDS"
+        },
+        "pollInterval": {
+          "objectValue": 60
+        },
+        "pollIntervalUnit": {
+          "stringValue": "SECONDS"
+        },
+        "requestURL": {
+          "stringValue": "https://iaas.${REGION}.oraclecloud.com/20180530/instanceAgentCommands/#{COMMAND_ID}/status?instanceId=${INSTANCE_ID}"
+        },
+        "pollCondition": {
+          "refValue": {
+            "modelType": "EXPRESSION",
+            "exprString": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'SUCCEEDED' AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'FAILED'"
+          }
+        }
+      }
+    }
+  },
+  "typedExpressions": [
+    {
+      "modelType": "TYPED_EXPRESSION",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 2000
+          }
+        }
+      },
+      "expression": "CAST(json_path(SYS.RESPONSE_PAYLOAD,'$.id') AS String)",
+      "name": "COMMAND_ID"
+    }
+  ],
+  "apiCallMode": "ASYNC_GENERIC",
+  "authConfig": {
+    "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+    "resourcePrincipalSource": "WORKSPACE"
+  },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }
+}

--- a/tasks/src/tasks/containerinstance/containerinstance.json
+++ b/tasks/src/tasks/containerinstance/containerinstance.json
@@ -1,0 +1,426 @@
+{
+    "modelType": "REST_TASK",
+    "key": "c404eef3-220b-43db-82cc-e59718c2bb0a",
+    "name": "Run Container Instance",
+    "description": "Run a container instance for a long running job. See https://www.oracle.com/cloud/cloud-native/container-instances/",
+    "identifier": "RUN_CONTAINER_INSTANCE",
+    "parameters": [
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request URL)"
+                    }
+                }
+            },
+            "description": "OCI Region name.",
+            "defaultValue": "us-ashburn-1",
+            "isInput": true,
+            "isOutput": false,
+            "name": "REGION",
+            "typeName": "STRING"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 4000
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "Container URL",
+            "defaultValue": "python",
+            "isInput": true,
+            "isOutput": false,
+            "name": "CONTAINER_URL_PATH",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "Compartment to create container instance in.",
+            "defaultValue": "ocid1.compartment.oc1..aaaaaaaa45umzgitiab4o5rodo67dnjov5lbbzbp54a3rdhzdd3hfdcmpz4a",
+            "isInput": true,
+            "isOutput": false,
+            "name": "COMPARTMENT_ID",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "",
+            "defaultValue": "nDUb:US-ASHBURN-AD-1",
+            "isInput": true,
+            "isOutput": false,
+            "name": "AVAILABILITY_DOMAIN",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "",
+            "defaultValue": "CI.Standard.E4.Flex",
+            "isInput": true,
+            "isOutput": false,
+            "name": "SHAPE",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/INTEGER",
+            "configValues": {
+                "configParamValues": {
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "",
+            "defaultValue": "1",
+            "isInput": true,
+            "isOutput": false,
+            "name": "OCPUS",
+            "typeName": "INTEGER"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/INTEGER",
+            "configValues": {
+                "configParamValues": {
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "",
+            "defaultValue": "1",
+            "isInput": true,
+            "isOutput": false,
+            "name": "MEMORY_IN_GB",
+            "typeName": "INTEGER"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "",
+            "defaultValue": "ocid1.subnet.oc1.iad....",
+            "isInput": true,
+            "isOutput": false,
+            "name": "SUBNET_ID",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "",
+            "defaultValue": "DISDatabaseVCN",
+            "isInput": true,
+            "isOutput": false,
+            "name": "VCN_NAME",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "",
+            "defaultValue": "container-instance-20230103-1628",
+            "isInput": true,
+            "isOutput": false,
+            "name": "CI_DISPLAY_NAME",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "",
+            "defaultValue": "NEVER",
+            "isInput": true,
+            "isOutput": false,
+            "name": "CONTAINER_RESTART_POLICY",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/INTEGER",
+            "configValues": {
+                "configParamValues": {
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "In seconds",
+            "defaultValue": "0",
+            "isInput": true,
+            "isOutput": false,
+            "name": "GRACEFUL_SHUTDOWN_TIME",
+            "typeName": "INTEGER"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 4000
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "",
+            "defaultValue": " ",
+            "isInput": true,
+            "isOutput": false,
+            "name": "ENVIRONMENT_VARS",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 4000
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "Entrypoint arguments.",
+            "defaultValue": " ",
+            "isInput": true,
+            "isOutput": false,
+            "name": "ENTRYPOINTARGUMENTS",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "key": "9a155a5e-4cc5-4afb-a14f-25d52e51939c",
+            "parentRef": {
+                "parent": "c404eef3-220b-43db-82cc-e59718c2bb0a"
+            },
+            "type": {
+                "modelType": "JAVA_TYPE",
+                "javaTypeName": "com.oracle.dicom.model.expression.Expression"
+            },
+            "description": "Polling condition.",
+            "defaultValue": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleDetails') AS String) != 'CONTAINER_TERMINATED' AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'DELETED'",
+            "isInput": true,
+            "isOutput": false,
+            "name": "POLLING_CONDITION",
+            "typeName": "com.oracle.dicom.model.expression.Expression"
+        },
+        {
+            "modelType": "PARAMETER",
+            "key": "fabbce00-eb8e-4dc1-9018-f3c5cc78c16a",
+            "parentRef": {
+                "parent": "c404eef3-220b-43db-82cc-e59718c2bb0a"
+            },
+            "type": {
+                "modelType": "JAVA_TYPE",
+                "javaTypeName": "com.oracle.dicom.model.expression.Expression"
+            },
+            "configValues": {
+                "configParamValues": {
+                    "usedInParam": {
+                        "stringValue": "Success Condition"
+                    }
+                }
+            },
+            "description": "Success condition.",
+            "defaultValue": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS <= 300 AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleDetails') AS String) == 'CONTAINER_TERMINATED'",
+            "isInput": true,
+            "isOutput": false,
+            "name": "SUCCESS_CONDITION",
+            "typeName": "com.oracle.dicom.model.expression.Expression"
+        },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "true",
+      "isInput": true,
+      "isOutput": false,
+      "name": "IS_PUBLIC_IP_ASSIGNED",
+      "typeName": "VARCHAR"
+    }
+    ],
+    "opConfigValues": {
+        "configParamValues": {
+            "successCondition": {
+                "parameterValue": "fabbce00-eb8e-4dc1-9018-f3c5cc78c16a"
+            }
+        },
+        "parentRef": {}
+    },
+    "executeRestCallConfig": {
+        "modelType": "REST_CALL_CONFIG",
+        "methodType": "POST",
+        "configValues": {
+            "configParamValues": {
+                "requestPayload": {
+                    "refValue": {
+                        "modelType": "JSON_TEXT",
+                        "encoded": false,
+                        "configValues": {
+                            "configParamValues": {
+                                "dataParam": {
+                                    "stringValue": "{\n    \"containers\": [\n        {\n            \"imageUrl\": \"${CONTAINER_URL_PATH}\",\n            \"displayName\": \"container-20230103-1629-1\",\n            \"environmentVariables\": { ${ENVIRONMENT_VARS} },\n      \t\t\t\"arguments\": [\n             ${ENTRYPOINTARGUMENTS}\n            ],\n \t          \"definedTags\": {},\n            \"freeformTags\": {}\n        }\n    ],\n    \"compartmentId\": \"${COMPARTMENT_ID}\",\n    \"availabilityDomain\": \"${AVAILABILITY_DOMAIN}\",\n    \"shape\": \"${SHAPE}\",\n    \"shapeConfig\": {\n        \"ocpus\": ${OCPUS},\n        \"memoryInGBs\": ${MEMORY_IN_GB}\n    },\n    \"vnics\": [\n        {\n            \"subnetId\": \"${SUBNET_ID}\",\n            \"displayName\": \"${VCN_NAME}\",\n            \"isPublicIpAssigned\": ${IS_PUBLIC_IP_ASSIGNED},\n            \"skipSourceDestCheck\": true\n        }\n    ],\n    \"displayName\": \"${CI_DISPLAY_NAME}\",\n    \"gracefulShutdownTimeoutInSeconds\": ${GRACEFUL_SHUTDOWN_TIME},\n    \"containerRestartPolicy\": \"${CONTAINER_RESTART_POLICY}\"\n}"
+                                }
+                            }
+                        }
+                    }
+                },
+                "requestURL": {
+                    "stringValue": "https://compute-containers.${REGION}.oci.oraclecloud.com/20210415/containerInstances"
+                }
+            }
+        }
+    },
+    "cancelRestCallConfig": {
+        "modelType": "REST_CALL_CONFIG",
+        "methodType": "DELETE"
+    },
+    "pollRestCallConfig": {
+        "modelType": "POLL_REST_CALL_CONFIG",
+        "methodType": "GET",
+        "configValues": {
+            "configParamValues": {
+                "pollMaxDuration": {
+                    "objectValue": 1000
+                },
+                "pollMaxDurationUnit": {
+                    "stringValue": "SECONDS"
+                },
+                "pollInterval": {
+                    "objectValue": 60
+                },
+                "pollIntervalUnit": {
+                    "stringValue": "SECONDS"
+                },
+                "requestURL": {
+                    "stringValue": "https://compute-containers.${REGION}.oci.oraclecloud.com/20210415/containers/#{CI_ID}"
+                },
+                "pollCondition": {
+                    "parameterValue": "9a155a5e-4cc5-4afb-a14f-25d52e51939c"
+                }
+            }
+        }
+    },
+    "typedExpressions": [
+        {
+            "modelType": "TYPED_EXPRESSION",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 2000
+                    }
+                }
+            },
+            "expression": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.containers[0].containerId') AS String)",
+            "name": "CI_ID"
+        }
+    ],
+    "apiCallMode": "ASYNC_GENERIC",
+    "authConfig": {
+        "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+        "resourcePrincipalSource": "WORKSPACE"
+    },
+    "registryMetadata": {
+        "aggregatorKey": "{{PROJECT_KEY}}"
+    }
+}

--- a/tasks/src/tasks/containerinstance/deletecontainerinstance.json
+++ b/tasks/src/tasks/containerinstance/deletecontainerinstance.json
@@ -1,0 +1,78 @@
+{
+  "modelType": "REST_TASK",
+  "name": "Delete Container Instance",
+  "description": "Delete container instance.",
+  "identifier": "DELETE_CONTAINER_INSTANCE",
+  "parameters": [
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL), Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Region.",
+      "defaultValue": "us-ashburn-1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "REGION",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Container instance ocid.",
+      "defaultValue": "enter_ocid",
+      "isInput": true,
+      "isOutput": false,
+      "name": "CONTAINER_INSTANCE_ID",
+      "typeName": "STRING"
+    }
+  ],
+  "opConfigValues": {
+    "configParamValues": {
+      "successCondition": {
+        "refValue": {
+          "modelType": "EXPRESSION",
+          "exprString": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS < 300"
+        }
+      }
+    }
+  },
+  "executeRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "DELETE",
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "https://compute-containers.${REGION}.oci.oraclecloud.com/20210415/containerInstances/${CONTAINER_INSTANCE_ID}"
+        }
+      }
+    }
+  },
+  "apiCallMode": "SYNCHRONOUS",
+  "authConfig": {
+    "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+    "resourcePrincipalSource": "WORKSPACE"
+  },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }
+}
+

--- a/tasks/src/tasks/containerinstance/pythoncontainerinstance.json
+++ b/tasks/src/tasks/containerinstance/pythoncontainerinstance.json
@@ -1,0 +1,372 @@
+{
+  "modelType": "REST_TASK",
+  "name": "Run Python Container Instance",
+  "identifier": "RUN_PYTHON_CONTAINR_INSTANCE",
+  "description": "Run a container instance for a long running job. See https://www.oracle.com/cloud/cloud-native/container-instances/",
+  "parameters": [
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Bucket name.",
+      "defaultValue": "bucketname",
+      "isInput": true,
+      "isOutput": false,
+      "name": "BUCKET_NAME",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 1000
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Python script name",
+      "defaultValue": "script.py",
+      "isInput": true,
+      "isOutput": false,
+      "name": "PYTHON_SCRIPT",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL),Polling API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "OCI Region name.",
+      "defaultValue": "us-ashburn-1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "REGION",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Compartment to create container instance in.",
+      "defaultValue": "ocid1.compartment.oc1.....",
+      "isInput": true,
+      "isOutput": false,
+      "name": "COMPARTMENT_ID",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "nDUb:US-ASHBURN-AD-1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "AVAILABILITY_DOMAIN",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "CI.Standard.E4.Flex",
+      "isInput": true,
+      "isOutput": false,
+      "name": "SHAPE",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/INTEGER",
+      "configValues": {
+        "configParamValues": {
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "OCPUS",
+      "typeName": "INTEGER"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/INTEGER",
+      "configValues": {
+        "configParamValues": {
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "MEMORY_IN_GB",
+      "typeName": "INTEGER"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Subnet OCID.",
+      "defaultValue": "ocid1.subnet.oc1.iad.....",
+      "isInput": true,
+      "isOutput": false,
+      "name": "SUBNET_ID",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Container instance job name.",
+      "defaultValue": "container-instance-job",
+      "isInput": true,
+      "isOutput": false,
+      "name": "CI_DISPLAY_NAME",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Environment variables, specified as VAR:VAL, ...",
+      "defaultValue": " ",
+      "isInput": true,
+      "isOutput": false,
+      "name": "ENVIRONMENT_VARS",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "container-job",
+      "isInput": true,
+      "isOutput": false,
+      "name": "JOB_NAME",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Container URL, by default using the OCI CLI container.",
+      "defaultValue": "ghcr.io/oracle/oci-cli",
+      "isInput": true,
+      "isOutput": false,
+      "name": "CONTAINER_URL_PATH",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "true",
+      "isInput": true,
+      "isOutput": false,
+      "name": "IS_PUBLIC_IP_ASSIGNED",
+      "typeName": "VARCHAR"
+    }
+  ],
+  "opConfigValues": {
+    "configParamValues": {
+      "successCondition": {
+        "refValue": {
+          "modelType": "EXPRESSION",
+          "exprString": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS <= 300 AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleDetails') AS String) == 'CONTAINER_TERMINATED'"
+        }
+      }
+    }
+  },
+  "executeRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "POST",
+    "configValues": {
+      "configParamValues": {
+        "requestPayload": {
+          "refValue": {
+            "modelType": "JSON_TEXT",
+            "encoded": false,
+            "configValues": {
+              "configParamValues": {
+                "dataParam": {
+                  "stringValue": "{\n \"containers\": [\n  { \n   \"imageUrl\": \"${CONTAINER_URL_PATH}\",\n   \"displayName\": \"${JOB_NAME}\",\n   \"environmentVariables\": { ${ENVIRONMENT_VARS} },\n   \"command\": [ \"/bin/sh\", \"-c\" ],\n   \"arguments\": [ \"oci --auth resource_principal os object get --bucket-name ${BUCKET_NAME} --name ${PYTHON_SCRIPT} --file -  | python3\" ],\n   \"definedTags\": {},\n   \"freeformTags\": {}\n  }\n ],\n \"compartmentId\": \"${COMPARTMENT_ID}\",\n \"availabilityDomain\": \"${AVAILABILITY_DOMAIN}\",\n \"shape\": \"${SHAPE}\",\n \"shapeConfig\": {\n  \"ocpus\": ${OCPUS},\n  \"memoryInGBs\": ${MEMORY_IN_GB}\n },\n \"vnics\": [\n  { \n   \"subnetId\": \"${SUBNET_ID}\",\n   \"isPublicIpAssigned\": ${IS_PUBLIC_IP_ASSIGNED},\n   \"skipSourceDestCheck\": true\n  } \n ],\n \"displayName\": \"${CI_DISPLAY_NAME}\",\n \"gracefulShutdownTimeoutInSeconds\": 0,\n \"containerRestartPolicy\": \"NEVER\"\n}"
+                }
+              }
+            }
+          }
+        },
+        "requestURL": {
+          "stringValue": "https://compute-containers.${REGION}.oci.oraclecloud.com/20210415/containerInstances"
+        }
+      }
+    }
+  },
+  "cancelRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "DELETE"
+  },
+  "pollRestCallConfig": {
+    "modelType": "POLL_REST_CALL_CONFIG",
+    "methodType": "GET",
+    "configValues": {
+      "configParamValues": {
+        "pollMaxDuration": {
+          "objectValue": 1000
+        },
+        "pollMaxDurationUnit": {
+          "stringValue": "SECONDS"
+        },
+        "pollInterval": {
+          "objectValue": 60
+        },
+        "pollIntervalUnit": {
+          "stringValue": "SECONDS"
+        },
+        "requestURL": {
+          "stringValue": "https://compute-containers.${REGION}.oci.oraclecloud.com/20210415/containers/#{CI_ID}"
+        },
+        "pollCondition": {
+          "refValue": {
+            "modelType": "EXPRESSION",
+            "exprString": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleDetails') AS String) != 'CONTAINER_TERMINATED' AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'DELETED'"
+          }
+        }
+      }
+    }
+  },
+  "typedExpressions": [
+    {
+      "modelType": "TYPED_EXPRESSION",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 2000
+          }
+        }
+      },
+      "expression": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.containers[0].containerId') AS String)",
+      "name": "CI_ID"
+    }
+  ],
+  "apiCallMode": "ASYNC_GENERIC",
+  "authConfig": {
+    "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+    "resourcePrincipalSource": "WORKSPACE"
+  },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }
+}

--- a/tasks/src/tasks/containerinstance/shellcontainerinstance.json
+++ b/tasks/src/tasks/containerinstance/shellcontainerinstance.json
@@ -1,0 +1,359 @@
+{
+  "modelType": "REST_TASK",
+  "name": "Run Shell Container Instance",
+  "description": "Run a container instance for a long running job. See https://www.oracle.com/cloud/cloud-native/container-instances/",
+  "identifier": "RUN_SHELL_CONTAINER_INSTANCE",
+  "parameters": [
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Shell commands, can also leverage OCI CLI.",
+      "defaultValue": "echo \\\"Hello World\\\"",
+      "isInput": true,
+      "isOutput": false,
+      "name": "SHELL_COMMANDS",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Subnet OCID",
+      "defaultValue": "ocid1.subnet.oc1.iad....",
+      "isInput": true,
+      "isOutput": false,
+      "name": "SUBNET_ID",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Container instance job name.",
+      "defaultValue": "container-instance-job",
+      "isInput": true,
+      "isOutput": false,
+      "name": "CI_DISPLAY_NAME",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "container-job",
+      "isInput": true,
+      "isOutput": false,
+      "name": "JOB_NAME",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Environment variables, specified as VAR:VAL, ...",
+      "defaultValue": " ",
+      "isInput": true,
+      "isOutput": false,
+      "name": "ENVIRONMENT_VARS",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL),Polling API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "OCI Region name.",
+      "defaultValue": "us-ashburn-1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "REGION",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Compartment to create container instance in.",
+      "defaultValue": "ocid1.compartment.oc1.....",
+      "isInput": true,
+      "isOutput": false,
+      "name": "COMPARTMENT_ID",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "nDUb:US-ASHBURN-AD-1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "AVAILABILITY_DOMAIN",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "CI.Standard.E4.Flex",
+      "isInput": true,
+      "isOutput": false,
+      "name": "SHAPE",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/INTEGER",
+      "configValues": {
+        "configParamValues": {
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "OCPUS",
+      "typeName": "INTEGER"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/INTEGER",
+      "configValues": {
+        "configParamValues": {
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "MEMORY_IN_GB",
+      "typeName": "INTEGER"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Container URL, by default using the OCI CLI container.",
+      "defaultValue": "ghcr.io/oracle/oci-cli",
+      "isInput": true,
+      "isOutput": false,
+      "name": "CONTAINER_URL_PATH",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "true",
+      "isInput": true,
+      "isOutput": false,
+      "name": "IS_PUBLIC_IP_ASSIGNED",
+      "typeName": "VARCHAR"
+    }
+  ],
+  "opConfigValues": {
+    "configParamValues": {
+      "successCondition": {
+        "refValue": {
+          "modelType": "EXPRESSION",
+          "exprString": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS <= 300 AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleDetails') AS String) == 'CONTAINER_TERMINATED'"
+         }
+      }
+    }
+  },
+  "executeRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "POST",
+    "configValues": {
+      "configParamValues": {
+        "requestPayload": {
+          "refValue": {
+            "modelType": "JSON_TEXT",
+            "encoded": false,
+            "configValues": {
+              "configParamValues": {
+                "dataParam": {
+                  "stringValue": "{\n \"containers\": [\n  { \n   \"imageUrl\": \"${CONTAINER_URL_PATH}\",\n   \"displayName\": \"${JOB_NAME}\",\n   \"environmentVariables\": { ${ENVIRONMENT_VARS} },\n   \"command\": [ \"/bin/sh\", \"-c\" ],\n   \"arguments\": [ \"${SHELL_COMMANDS}\" ],\n   \"definedTags\": {},\n   \"freeformTags\": {}\n  }\n ],\n \"compartmentId\": \"${COMPARTMENT_ID}\",\n \"availabilityDomain\": \"${AVAILABILITY_DOMAIN}\",\n \"shape\": \"${SHAPE}\",\n \"shapeConfig\": {\n  \"ocpus\": ${OCPUS},\n  \"memoryInGBs\": ${MEMORY_IN_GB}\n },\n \"vnics\": [\n  { \n   \"subnetId\": \"${SUBNET_ID}\",\n   \"isPublicIpAssigned\": ${IS_PUBLIC_IP_ASSIGNED},\n   \"skipSourceDestCheck\": true\n  } \n ],\n \"displayName\": \"${CI_DISPLAY_NAME}\",\n \"gracefulShutdownTimeoutInSeconds\": 0,\n \"containerRestartPolicy\": \"NEVER\"\n}"
+                }
+              }
+            }
+          }
+        },
+        "requestURL": {
+          "stringValue": "https://compute-containers.${REGION}.oci.oraclecloud.com/20210415/containerInstances"
+        }
+      }
+    }
+  },
+  "cancelRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "DELETE",
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "https://compute-containers.${REGION}.oci.oraclecloud.com/20210415/containers/#{CI_ID}"
+        }
+      }
+    }
+  },
+  "pollRestCallConfig": {
+    "modelType": "POLL_REST_CALL_CONFIG",
+    "methodType": "GET",
+    "configValues": {
+      "configParamValues": {
+        "pollMaxDuration": {
+          "objectValue": 1000
+        },
+        "pollMaxDurationUnit": {
+          "stringValue": "SECONDS"
+        },
+        "pollInterval": {
+          "objectValue": 60
+        },
+        "pollIntervalUnit": {
+          "stringValue": "SECONDS"
+        },
+        "requestURL": {
+          "stringValue": "https://compute-containers.${REGION}.oci.oraclecloud.com/20210415/containers/#{CI_ID}"
+        },
+        "pollCondition": {
+          "refValue": {
+            "modelType": "EXPRESSION",
+            "exprString": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleDetails') AS String) != 'CONTAINER_TERMINATED' AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'DELETED'"
+          }
+        }
+      }
+    }
+  },
+  "typedExpressions": [
+    {
+      "modelType": "TYPED_EXPRESSION",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 2000
+          }
+        }
+      },
+      "expression": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.containers[0].containerId') AS String)",
+      "name": "CI_ID"
+    }
+  ],
+  "apiCallMode": "ASYNC_GENERIC",
+  "authConfig": {
+    "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+    "resourcePrincipalSource": "WORKSPACE"
+  },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }
+}

--- a/tasks/src/tasks/dataflow/rundataflow.json
+++ b/tasks/src/tasks/dataflow/rundataflow.json
@@ -1,0 +1,424 @@
+{
+    "modelType": "REST_TASK",
+    "name": "Execute OCI Dataflow Job",
+    "description": "REST task for OCI Dataflow, decide how much or little you want to parameterize and how, also pick up latest and greatest features.",
+    "identifier": "EXECUTE_OCI_DATAFLOW_JOB",
+    "parameters": [
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Termination API Config: (Request URL)"
+                    }
+                }
+            },
+            "description": "Region",
+            "defaultValue": "us-ashburn-1",
+            "isInput": true,
+            "isOutput": false,
+            "name": "REGION",
+            "typeName": "STRING"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "Compartment id for application.",
+            "defaultValue": "compartmentid",
+            "isInput": true,
+            "isOutput": false,
+            "name": "COMPARTMENT_ID",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "Display name",
+            "defaultValue": "PySpark CSV to Parquet",
+            "isInput": true,
+            "isOutput": false,
+            "name": "DISPLAY_NAME",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "Spark version.",
+            "defaultValue": "3.2.1",
+            "isInput": true,
+            "isOutput": false,
+            "name": "SPARK_VERSION",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "Driver shape.",
+            "defaultValue": "VM.Standard2.1",
+            "isInput": true,
+            "isOutput": false,
+            "name": "DRIVER_SHAPE",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "Executor shape.",
+            "defaultValue": "VM.Standard2.1",
+            "isInput": true,
+            "isOutput": false,
+            "name": "EXECUTOR_SHAPE",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/INTEGER",
+            "configValues": {
+                "configParamValues": {
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "The number of executor VMs requested.",
+            "defaultValue": "1",
+            "isInput": true,
+            "isOutput": false,
+            "name": "NUM_EXECUTORS",
+            "typeName": "INTEGER"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 4000
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "The input used for spark-submit command. ",
+            "defaultValue": "execute_cmd",
+            "isInput": true,
+            "isOutput": false,
+            "name": "EXECUTE_CMD",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "Job type, could be batch or streaming.",
+            "defaultValue": "BATCH",
+            "isInput": true,
+            "isOutput": false,
+            "name": "JOB_TYPE",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 4000
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "Parameters",
+            "defaultValue": " ",
+            "isInput": true,
+            "isOutput": false,
+            "name": "PARAMETERS",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 4000
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "Logs bucket URI.",
+            "defaultValue": "oci://bucketname@namespace/",
+            "isInput": true,
+            "isOutput": false,
+            "name": "LOGS_BUCKET_URI",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 4000
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "An Oracle Cloud Infrastructure URI of the bucket to be used as default warehouse directory for BATCH SQL runs.",
+            "defaultValue": " ",
+            "isInput": true,
+            "isOutput": false,
+            "name": "WAREHOUSE_BUCKET_URI",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "",
+            "defaultValue": " ",
+            "isInput": true,
+            "isOutput": false,
+            "name": "PRIVATE_ENDPOINT_ID",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 4000
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "",
+            "defaultValue": " ",
+            "isInput": true,
+            "isOutput": false,
+            "name": "CONFIGURATION",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "",
+            "defaultValue": " ",
+            "isInput": true,
+            "isOutput": false,
+            "name": "ARCHIVE_URI",
+            "typeName": "VARCHAR"
+        }
+    ],
+    "opConfigValues": {
+        "configParamValues": {
+            "successCondition": {
+                "refValue": {
+                    "modelType": "EXPRESSION",
+                    "key": "ade38dcc-9855-4d91-83cb-2e4e2dbedf3b",
+                    "exprString": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS <= 300 AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) == 'SUCCEEDED'",
+                    "configValues": {
+                        "parentRef": {
+                            "parent": "ade38dcc-9855-4d91-83cb-2e4e2dbedf3b"
+                        }
+                    }
+                }
+            }
+        },
+        "parentRef": {}
+    },
+    "isConcurrentAllowed": true,
+    "executeRestCallConfig": {
+        "modelType": "REST_CALL_CONFIG",
+        "key": "fc80f86d-c545-46b2-94fd-423a1c7718f9",
+        "methodType": "POST",
+        "requestHeaders": {
+            "Content-Type": "application/json"
+        },
+        "configValues": {
+            "configParamValues": {
+                "requestURL": {
+                    "stringValue": "https://dataflow.${REGION}.oci.oraclecloud.com/20200129/runs"
+                },
+                "requestPayload": {
+                    "refValue": {
+                        "modelType": "JSON_TEXT",
+                        "parentRef": {
+                            "parent": "fc80f86d-c545-46b2-94fd-423a1c7718f9"
+                        },
+                        "encoded": false,
+                        "configValues": {
+                            "configParamValues": {
+                                "dataParam": {
+                                    "stringValue": "{\n \"compartmentId\": \"${COMPARTMENT_ID}\",\n \"displayName\": \"${DISPLAY_NAME}\",\n \"sparkVersion\": \"${SPARK_VERSION}\",\n \"driverShape\": \"${DRIVER_SHAPE}\",\n \"executorShape\": \"${EXECUTOR_SHAPE}\",\n \"numExecutors\": ${NUM_EXECUTORS},\n \"execute\": \"${EXECUTE_CMD}\",\n \"maxDurationInMinutes\":-1,\n \"configuration\":{${CONFIGURATION}},\n \"parameters\":[${PARAMETERS}],\n \"archiveUri\":\"${ARCHIVE_URI}\",\n \"type\":\"${JOB_TYPE}\",\n \"logsBucketUri\": \"${LOGS_BUCKET_URI}\",\n \"privateEndpointId\":\"${PRIVATE_ENDPOINT_ID}\",\n \"warehouseBucketUri\":\"${WAREHOUSE_BUCKET_URI}\",\n \"poolId\": \"\",\n \"freeformTags\":{},\n \"definedTags\":{}\n}\n"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "cancelRestCallConfig": {
+        "modelType": "REST_CALL_CONFIG",
+        "methodType": "DELETE",
+        "configValues": {
+            "configParamValues": {
+                "requestURL": {
+                    "stringValue": "https://dataflow.${REGION}.oci.oraclecloud.com/20200129/runs/#{ID}"
+                }
+            }
+        }
+    },
+    "pollRestCallConfig": {
+        "modelType": "POLL_REST_CALL_CONFIG",
+        "key": "730c219c-5ec9-47b7-9993-a369ba785069",
+        "methodType": "GET",
+        "requestHeaders": {},
+        "configValues": {
+            "configParamValues": {
+                "pollMaxDuration": {
+                    "objectValue": 60000
+                },
+                "pollMaxDurationUnit": {
+                    "stringValue": "SECONDS"
+                },
+                "pollInterval": {
+                    "objectValue": 60
+                },
+                "pollIntervalUnit": {
+                    "stringValue": "SECONDS"
+                },
+                "requestURL": {
+                    "stringValue": "https://dataflow.${REGION}.oci.oraclecloud.com/20200129/runs/#{ID}"
+                },
+                "pollCondition": {
+                    "refValue": {
+                        "modelType": "EXPRESSION",
+                        "parentRef": {
+                            "parent": "730c219c-5ec9-47b7-9993-a369ba785069"
+                        },
+                        "exprString": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'SUCCEEDED' AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'FAILED'",
+                        "configValues": {
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "typedExpressions": [
+        {
+            "modelType": "TYPED_EXPRESSION",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 2000
+                    }
+                }
+            },
+            "expression": "json_path(SYS.RESPONSE_PAYLOAD_JSON, '$.id')",
+            "name": "ID"
+        }
+    ],
+    "apiCallMode": "ASYNC_GENERIC",
+    "authConfig": {
+        "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+        "resourcePrincipalSource": "WORKSPACE"
+    },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }   
+}

--- a/tasks/src/tasks/dataflow/rundataflowapp.json
+++ b/tasks/src/tasks/dataflow/rundataflowapp.json
@@ -1,0 +1,410 @@
+{
+    "modelType": "REST_TASK",
+    "name": "Execute OCI Dataflow Application",
+    "identifier": "EXECUTE_OCI_DATAFLOW_APPLICATION",
+    "parameters": [
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Termination API Config: (Request URL)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "Region",
+            "defaultValue": "us-ashburn-1",
+            "isInput": true,
+            "isOutput": false,
+            "name": "REGION",
+            "typeName": "STRING"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "Compartment id for application.",
+            "defaultValue": "compartmentid",
+            "isInput": true,
+            "isOutput": false,
+            "name": "COMPARTMENT_ID",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "Display name",
+            "defaultValue": "PySpark CSV to Parquet",
+            "isInput": true,
+            "isOutput": false,
+            "name": "DISPLAY_NAME",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "Driver shape.",
+            "defaultValue": "VM.Standard2.1",
+            "isInput": true,
+            "isOutput": false,
+            "name": "DRIVER_SHAPE",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "Executor shape.",
+            "defaultValue": "VM.Standard2.1",
+            "isInput": true,
+            "isOutput": false,
+            "name": "EXECUTOR_SHAPE",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/INTEGER",
+            "configValues": {
+                "configParamValues": {
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "The number of executor VMs requested.",
+            "defaultValue": "1",
+            "isInput": true,
+            "isOutput": false,
+            "name": "NUM_EXECUTORS",
+            "typeName": "INTEGER"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "Job type, could be batch or streaming.",
+            "defaultValue": "BATCH",
+            "isInput": true,
+            "isOutput": false,
+            "name": "JOB_TYPE",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 4000
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "Parameters",
+            "defaultValue": " ",
+            "isInput": true,
+            "isOutput": false,
+            "name": "PARAMETERS",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 4000
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "Logs bucket URI.",
+            "defaultValue": "oci://bucketname@namespace/",
+            "isInput": true,
+            "isOutput": false,
+            "name": "LOGS_BUCKET_URI",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 4000
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "An Oracle Cloud Infrastructure URI of the bucket to be used as default warehouse directory for BATCH SQL runs.",
+            "defaultValue": " ",
+            "isInput": true,
+            "isOutput": false,
+            "name": "WAREHOUSE_BUCKET_URI",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "",
+            "defaultValue": " ",
+            "isInput": true,
+            "isOutput": false,
+            "name": "PRIVATE_ENDPOINT_ID",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 4000
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "",
+            "defaultValue": " ",
+            "isInput": true,
+            "isOutput": false,
+            "name": "CONFIGURATION",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "",
+            "defaultValue": " ",
+            "isInput": true,
+            "isOutput": false,
+            "name": "ARCHIVE_URI",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "OCI Dataflow application id.",
+            "defaultValue": "application",
+            "isInput": true,
+            "isOutput": false,
+            "name": "APPLICATION_ID",
+            "typeName": "VARCHAR"
+        }
+    ],
+    "opConfigValues": {
+        "configParamValues": {
+            "successCondition": {
+                "refValue": {
+                    "modelType": "EXPRESSION",
+                    "exprString": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS <= 300 AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) == 'SUCCEEDED'"
+                }
+            }
+        }
+    },
+    "isConcurrentAllowed": true,
+    "executeRestCallConfig": {
+        "modelType": "REST_CALL_CONFIG",
+        "key": "131eede9-4a81-42d6-bcbc-482d77c63296",
+        "methodType": "POST",
+        "requestHeaders": {
+            "Content-Type": "application/json"
+        },
+        "configValues": {
+            "configParamValues": {
+                "requestURL": {
+                    "stringValue": "https://dataflow.${REGION}.oci.oraclecloud.com/20200129/runs"
+                },
+                "requestPayload": {
+                    "refValue": {
+                        "modelType": "JSON_TEXT",
+                        "parentRef": {
+                            "parent": "131eede9-4a81-42d6-bcbc-482d77c63296"
+                        },
+                        "encoded": false,
+                        "configValues": {
+                            "configParamValues": {
+                                "dataParam": {
+                                    "stringValue": "{\n \"applicationId\": \"${APPLICATION_ID}\",\n \"compartmentId\": \"${COMPARTMENT_ID}\",\n \"displayName\": \"${DISPLAY_NAME}\",\n \"driverShape\": \"${DRIVER_SHAPE}\",\n \"executorShape\": \"${EXECUTOR_SHAPE}\",\n \"numExecutors\": ${NUM_EXECUTORS},\n \"maxDurationInMinutes\":-1,\n \"configuration\":{${CONFIGURATION}},\n \"poolId\":\"\",\n \"parameters\":[${PARAMETERS}],\n \"archiveUri\":\"${ARCHIVE_URI}\",\n \"type\":\"${JOB_TYPE}\",\n \"logsBucketUri\": \"${LOGS_BUCKET_URI}\",\n \"privateEndpointId\":\"${PRIVATE_ENDPOINT_ID}\",\n \"warehouseBucketUri\":\"${WAREHOUSE_BUCKET_URI}\",\n \"freeformTags\":{},\n \"definedTags\":{}\n}\n"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "cancelRestCallConfig": {
+        "modelType": "REST_CALL_CONFIG",
+        "methodType": "DELETE",
+        "requestHeaders": {},
+        "configValues": {
+            "configParamValues": {
+                "requestURL": {
+                    "stringValue": "https://dataflow.${REGION}.oci.oraclecloud.com/20200129/runs/#{ID}"
+                }
+            }
+        }
+    },
+    "pollRestCallConfig": {
+        "modelType": "POLL_REST_CALL_CONFIG",
+        "key": "e747b89a-e27c-419d-84e4-6776a666131d",
+        "methodType": "GET",
+        "requestHeaders": {},
+        "configValues": {
+            "configParamValues": {
+                "pollMaxDuration": {
+                    "objectValue": 60000
+                },
+                "pollMaxDurationUnit": {
+                    "stringValue": "SECONDS"
+                },
+                "pollInterval": {
+                    "objectValue": 60
+                },
+                "pollIntervalUnit": {
+                    "stringValue": "SECONDS"
+                },
+                "requestURL": {
+                    "stringValue": "https://dataflow.${REGION}.oci.oraclecloud.com/20200129/runs/#{ID}"
+                },
+                "pollCondition": {
+                    "refValue": {
+                        "modelType": "EXPRESSION",
+                        "parentRef": {
+                            "parent": "e747b89a-e27c-419d-84e4-6776a666131d"
+                        },
+                        "exprString": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'SUCCEEDED' AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'FAILED'"
+                    }
+                }
+            }
+        }
+    },
+    "typedExpressions": [
+        {
+            "modelType": "TYPED_EXPRESSION",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 2000
+                    }
+                },
+                "parentRef": {}
+            },
+            "expression": "json_path(SYS.RESPONSE_PAYLOAD_JSON, '$.id')",
+            "name": "ID"
+        }
+    ],
+    "apiCallMode": "ASYNC_GENERIC",
+    "authConfig": {
+        "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+        "resourcePrincipalSource": "WORKSPACE"
+    },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }         
+}

--- a/tasks/src/tasks/dataflow/rundataflowapppool.json
+++ b/tasks/src/tasks/dataflow/rundataflowapppool.json
@@ -1,0 +1,431 @@
+{
+    "modelType": "REST_TASK",
+    "name": "Execute OCI Dataflow Application With Pool",
+    "identifier": "EXECUTE_OCI_DATAFLOW_APPLICATION_WITH_POOL",
+    "parameters": [
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Termination API Config: (Request URL)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "Region",
+            "defaultValue": "us-ashburn-1",
+            "isInput": true,
+            "isOutput": false,
+            "name": "REGION",
+            "typeName": "STRING"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "Compartment id for application.",
+            "defaultValue": "compartmentid",
+            "isInput": true,
+            "isOutput": false,
+            "name": "COMPARTMENT_ID",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "Display name",
+            "defaultValue": "PySpark CSV to Parquet",
+            "isInput": true,
+            "isOutput": false,
+            "name": "DISPLAY_NAME",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "Driver shape.",
+            "defaultValue": "VM.Standard2.1",
+            "isInput": true,
+            "isOutput": false,
+            "name": "DRIVER_SHAPE",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "Executor shape.",
+            "defaultValue": "VM.Standard2.1",
+            "isInput": true,
+            "isOutput": false,
+            "name": "EXECUTOR_SHAPE",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/INTEGER",
+            "configValues": {
+                "configParamValues": {
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "The number of executor VMs requested.",
+            "defaultValue": "1",
+            "isInput": true,
+            "isOutput": false,
+            "name": "NUM_EXECUTORS",
+            "typeName": "INTEGER"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "Job type, could be batch or streaming.",
+            "defaultValue": "BATCH",
+            "isInput": true,
+            "isOutput": false,
+            "name": "JOB_TYPE",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 4000
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "Parameters",
+            "defaultValue": " ",
+            "isInput": true,
+            "isOutput": false,
+            "name": "PARAMETERS",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 4000
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "Logs bucket URI.",
+            "defaultValue": "oci://bucketname@namespace/",
+            "isInput": true,
+            "isOutput": false,
+            "name": "LOGS_BUCKET_URI",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 4000
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "An Oracle Cloud Infrastructure URI of the bucket to be used as default warehouse directory for BATCH SQL runs.",
+            "defaultValue": " ",
+            "isInput": true,
+            "isOutput": false,
+            "name": "WAREHOUSE_BUCKET_URI",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "",
+            "defaultValue": " ",
+            "isInput": true,
+            "isOutput": false,
+            "name": "PRIVATE_ENDPOINT_ID",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 4000
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "",
+            "defaultValue": " ",
+            "isInput": true,
+            "isOutput": false,
+            "name": "CONFIGURATION",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "",
+            "defaultValue": " ",
+            "isInput": true,
+            "isOutput": false,
+            "name": "POOL_ID",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "",
+            "defaultValue": " ",
+            "isInput": true,
+            "isOutput": false,
+            "name": "ARCHIVE_URI",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                },
+                "parentRef": {}
+            },
+            "description": "OCI Dataflow application id.",
+            "defaultValue": "application",
+            "isInput": true,
+            "isOutput": false,
+            "name": "APPLICATION_ID",
+            "typeName": "VARCHAR"
+        }
+    ],
+    "opConfigValues": {
+        "configParamValues": {
+            "successCondition": {
+                "refValue": {
+                    "modelType": "EXPRESSION",
+                    "exprString": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS <= 300 AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) == 'SUCCEEDED'"
+                }
+            }
+        }
+    },
+    "isConcurrentAllowed": true,
+    "executeRestCallConfig": {
+        "modelType": "REST_CALL_CONFIG",
+        "key": "131eede9-4a81-42d6-bcbc-482d77c63296",
+        "methodType": "POST",
+        "requestHeaders": {
+            "Content-Type": "application/json"
+        },
+        "configValues": {
+            "configParamValues": {
+                "requestURL": {
+                    "stringValue": "https://dataflow.${REGION}.oci.oraclecloud.com/20200129/runs"
+                },
+                "requestPayload": {
+                    "refValue": {
+                        "modelType": "JSON_TEXT",
+                        "parentRef": {
+                            "parent": "131eede9-4a81-42d6-bcbc-482d77c63296"
+                        },
+                        "encoded": false,
+                        "configValues": {
+                            "configParamValues": {
+                                "dataParam": {
+                                    "stringValue": "{\n \"applicationId\": \"${APPLICATION_ID}\",\n \"compartmentId\": \"${COMPARTMENT_ID}\",\n \"displayName\": \"${DISPLAY_NAME}\",\n \"driverShape\": \"${DRIVER_SHAPE}\",\n \"executorShape\": \"${EXECUTOR_SHAPE}\",\n \"numExecutors\": ${NUM_EXECUTORS},\n \"maxDurationInMinutes\":-1,\n \"configuration\":{${CONFIGURATION}},\n \"poolId\":\"${POOL_ID}\",\n \"parameters\":[${PARAMETERS}],\n \"archiveUri\":\"${ARCHIVE_URI}\",\n \"type\":\"${JOB_TYPE}\",\n \"logsBucketUri\": \"${LOGS_BUCKET_URI}\",\n \"privateEndpointId\":\"${PRIVATE_ENDPOINT_ID}\",\n \"warehouseBucketUri\":\"${WAREHOUSE_BUCKET_URI}\",\n \"freeformTags\":{},\n \"definedTags\":{}\n}\n"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "cancelRestCallConfig": {
+        "modelType": "REST_CALL_CONFIG",
+        "methodType": "DELETE",
+        "requestHeaders": {},
+        "configValues": {
+            "configParamValues": {
+                "requestURL": {
+                    "stringValue": "https://dataflow.${REGION}.oci.oraclecloud.com/20200129/runs/#{ID}"
+                }
+            }
+        }
+    },
+    "pollRestCallConfig": {
+        "modelType": "POLL_REST_CALL_CONFIG",
+        "key": "e747b89a-e27c-419d-84e4-6776a666131d",
+        "methodType": "GET",
+        "requestHeaders": {},
+        "configValues": {
+            "configParamValues": {
+                "pollMaxDuration": {
+                    "objectValue": 60000
+                },
+                "pollMaxDurationUnit": {
+                    "stringValue": "SECONDS"
+                },
+                "pollInterval": {
+                    "objectValue": 60
+                },
+                "pollIntervalUnit": {
+                    "stringValue": "SECONDS"
+                },
+                "requestURL": {
+                    "stringValue": "https://dataflow.${REGION}.oci.oraclecloud.com/20200129/runs/#{ID}"
+                },
+                "pollCondition": {
+                    "refValue": {
+                        "modelType": "EXPRESSION",
+                        "parentRef": {
+                            "parent": "e747b89a-e27c-419d-84e4-6776a666131d"
+                        },
+                        "exprString": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'SUCCEEDED' AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'FAILED'"
+                    }
+                }
+            }
+        }
+    },
+    "typedExpressions": [
+        {
+            "modelType": "TYPED_EXPRESSION",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 2000
+                    }
+                },
+                "parentRef": {}
+            },
+            "expression": "json_path(SYS.RESPONSE_PAYLOAD_JSON, '$.id')",
+            "name": "ID"
+        }
+    ],
+    "apiCallMode": "ASYNC_GENERIC",
+    "authConfig": {
+        "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+        "resourcePrincipalSource": "WORKSPACE"
+    },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }         
+}

--- a/tasks/src/tasks/dataflow/rundataflowpool.json
+++ b/tasks/src/tasks/dataflow/rundataflowpool.json
@@ -1,0 +1,443 @@
+{
+    "modelType": "REST_TASK",
+    "name": "Execute OCI Dataflow Job With Pool",
+    "identifier": "EXECUTE_OCI_DATAFLOW_JOB_WITH_POOL",
+    "parameters": [
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Termination API Config: (Request URL),Polling API Config: (Request URL)"
+                    }
+                }
+            },
+            "description": "Region",
+            "defaultValue": "us-ashburn-1",
+            "isInput": true,
+            "isOutput": false,
+            "name": "REGION",
+            "typeName": "STRING"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "Compartment id for application.",
+            "defaultValue": "compartmentid",
+            "isInput": true,
+            "isOutput": false,
+            "name": "COMPARTMENT_ID",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "Display name",
+            "defaultValue": "PySpark CSV to Parquet",
+            "isInput": true,
+            "isOutput": false,
+            "name": "DISPLAY_NAME",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "Spark version.",
+            "defaultValue": "3.2.1",
+            "isInput": true,
+            "isOutput": false,
+            "name": "SPARK_VERSION",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "Driver shape.",
+            "defaultValue": "VM.Standard2.1",
+            "isInput": true,
+            "isOutput": false,
+            "name": "DRIVER_SHAPE",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "Executor shape.",
+            "defaultValue": "VM.Standard2.1",
+            "isInput": true,
+            "isOutput": false,
+            "name": "EXECUTOR_SHAPE",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/INTEGER",
+            "configValues": {
+                "configParamValues": {
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "The number of executor VMs requested.",
+            "defaultValue": "1",
+            "isInput": true,
+            "isOutput": false,
+            "name": "NUM_EXECUTORS",
+            "typeName": "INTEGER"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 4000
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "The input used for spark-submit command. ",
+            "defaultValue": "execute_cmd",
+            "isInput": true,
+            "isOutput": false,
+            "name": "EXECUTE_CMD",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "Job type, could be batch or streaming.",
+            "defaultValue": "BATCH",
+            "isInput": true,
+            "isOutput": false,
+            "name": "JOB_TYPE",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 4000
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "Parameters",
+            "defaultValue": " ",
+            "isInput": true,
+            "isOutput": false,
+            "name": "PARAMETERS",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 4000
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "Logs bucket URI.",
+            "defaultValue": "oci://bucketname@namespace/",
+            "isInput": true,
+            "isOutput": false,
+            "name": "LOGS_BUCKET_URI",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 4000
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "An Oracle Cloud Infrastructure URI of the bucket to be used as default warehouse directory for BATCH SQL runs.",
+            "defaultValue": " ",
+            "isInput": true,
+            "isOutput": false,
+            "name": "WAREHOUSE_BUCKET_URI",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "",
+            "defaultValue": " ",
+            "isInput": true,
+            "isOutput": false,
+            "name": "PRIVATE_ENDPOINT_ID",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 4000
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "",
+            "defaultValue": " ",
+            "isInput": true,
+            "isOutput": false,
+            "name": "CONFIGURATION",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "",
+            "defaultValue": " ",
+            "isInput": true,
+            "isOutput": false,
+            "name": "POOL_ID",
+            "typeName": "VARCHAR"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "",
+            "defaultValue": " ",
+            "isInput": true,
+            "isOutput": false,
+            "name": "ARCHIVE_URI",
+            "typeName": "VARCHAR"
+        }
+    ],
+    "opConfigValues": {
+        "configParamValues": {
+            "successCondition": {
+                "refValue": {
+                    "modelType": "EXPRESSION",
+                    "key": "7179a011-6fa6-4957-abe8-a565fc197ad9",
+                    "exprString": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS <= 300 AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) == 'SUCCEEDED'",
+                    "configValues": {
+                        "parentRef": {
+                            "parent": "7179a011-6fa6-4957-abe8-a565fc197ad9"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "isConcurrentAllowed": true,
+    "executeRestCallConfig": {
+        "modelType": "REST_CALL_CONFIG",
+        "key": "ecf947c8-6e81-4b3d-9def-d43053bcab8f",
+        "methodType": "POST",
+        "requestHeaders": {
+            "Content-Type": "application/json"
+        },
+        "configValues": {
+            "configParamValues": {
+                "requestURL": {
+                    "stringValue": "https://dataflow.${REGION}.oci.oraclecloud.com/20200129/runs"
+                },
+                "requestPayload": {
+                    "refValue": {
+                        "modelType": "JSON_TEXT",
+                        "parentRef": {
+                            "parent": "ecf947c8-6e81-4b3d-9def-d43053bcab8f"
+                        },
+                        "encoded": false,
+                        "configValues": {
+                            "configParamValues": {
+                                "dataParam": {
+                                    "stringValue": "{\n \"compartmentId\": \"${COMPARTMENT_ID}\",\n \"displayName\": \"${DISPLAY_NAME}\",\n \"sparkVersion\": \"${SPARK_VERSION}\",\n \"driverShape\": \"${DRIVER_SHAPE}\",\n \"executorShape\": \"${EXECUTOR_SHAPE}\",\n \"numExecutors\": ${NUM_EXECUTORS},\n \"execute\": \"${EXECUTE_CMD}\",\n \"maxDurationInMinutes\":-1,\n \"configuration\":{${CONFIGURATION}},\n \"poolId\":\"${POOL_ID}\",\n \"parameters\":[${PARAMETERS}],\n \"archiveUri\":\"${ARCHIVE_URI}\",\n \"type\":\"${JOB_TYPE}\",\n \"logsBucketUri\": \"${LOGS_BUCKET_URI}\",\n \"privateEndpointId\":\"${PRIVATE_ENDPOINT_ID}\",\n \"warehouseBucketUri\":\"${WAREHOUSE_BUCKET_URI}\",\n \"freeformTags\":{},\n \"definedTags\":{}\n}\n"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "cancelRestCallConfig": {
+        "modelType": "REST_CALL_CONFIG",
+        "methodType": "DELETE",
+        "requestHeaders": {},
+        "configValues": {
+            "configParamValues": {
+                "requestURL": {
+                    "stringValue": "https://dataflow.${REGION}.oci.oraclecloud.com/20200129/runs/#{ID}"
+                }
+            }
+        }
+    },
+    "pollRestCallConfig": {
+        "modelType": "POLL_REST_CALL_CONFIG",
+        "key": "a52d37fc-8886-4507-b929-aa0063379afc",
+        "methodType": "GET",
+        "requestHeaders": {},
+        "configValues": {
+            "configParamValues": {
+                "pollMaxDuration": {
+                    "objectValue": 60000
+                },
+                "pollMaxDurationUnit": {
+                    "stringValue": "SECONDS"
+                },
+                "pollInterval": {
+                    "objectValue": 60
+                },
+                "pollIntervalUnit": {
+                    "stringValue": "SECONDS"
+                },
+                "requestURL": {
+                    "stringValue": "https://dataflow.${REGION}.oci.oraclecloud.com/20200129/runs/#{ID}"
+                },
+                "pollCondition": {
+                    "refValue": {
+                        "modelType": "EXPRESSION",
+                        "parentRef": {
+                            "parent": "a52d37fc-8886-4507-b929-aa0063379afc"
+                        },
+                        "exprString": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'SUCCEEDED' AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'FAILED'",
+                        "configValues": {
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "typedExpressions": [
+        {
+            "modelType": "TYPED_EXPRESSION",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 2000
+                    }
+                }
+            },
+            "expression": "json_path(SYS.RESPONSE_PAYLOAD_JSON, '$.id')",
+            "name": "ID"
+        }
+    ],
+    "apiCallMode": "ASYNC_GENERIC",
+    "authConfig": {
+        "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+        "resourcePrincipalSource": "WORKSPACE"
+    },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }   
+}

--- a/tasks/src/tasks/dataintegration/checklasttaskrunstate.json
+++ b/tasks/src/tasks/dataintegration/checklasttaskrunstate.json
@@ -1,0 +1,118 @@
+{
+  "modelType": "REST_TASK",
+  "name": "Check Last Task Run State",
+  "description": "Check last task run status. The task must be in the same application that this task is deployed into (since the system parameter application key is used). ",
+  "identifier": "CHECK_LAST_TASK_RUN_STATE",
+  "parameters": [
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Task type, one of INTEGRATION_TASK, DATA_LOADER_TASK, REST_TASK, PIPELINE_TASK, SQL_TASK",
+      "defaultValue": "INTEGRATION_TASK",
+      "isInput": true,
+      "isOutput": false,
+      "name": "TASK_TYPE",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "The task name, task runs will be listed using nameStartsWith",
+      "defaultValue": "ParamDemo_Task",
+      "isInput": true,
+      "isOutput": false,
+      "name": "TASK_NAME",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Success Condition, Success Condition, Success Condition, Success Condition"
+          }
+        }
+      },
+      "description": "Task status, one of NOT_STARTED, QUEUED, RUNNING, TERMINATING, TERMINATED, SUCCESS, ERROR\n",
+      "defaultValue": "SUCCESS",
+      "isInput": true,
+      "isOutput": false,
+      "name": "TASK_STATUS",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/BOOLEAN",
+      "configValues": {
+        "configParamValues": {
+          "usedInParam": {
+            "stringValue": "Success Condition, Success Condition, Success Condition"
+          }
+        }
+      },
+      "description": "Condition to include ",
+      "defaultValue": "true",
+      "isInput": true,
+      "isOutput": false,
+      "name": "CONDITION",
+      "typeName": "BOOLEAN"
+    }
+  ],
+  "opConfigValues": {
+    "configParamValues": {
+      "successCondition": {
+        "refValue": {
+          "modelType": "EXPRESSION",
+          "exprString": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS < 300 AND (CAST(JSON_PATH(SYS.RESPONSE_PAYLOAD, '$.items[0].status') as String) == '${TASK_STATUS}' OR  ${CONDITION})"
+        }
+      }
+    }
+  },
+  "isConcurrentAllowed": true,
+  "executeRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "GET",
+    "requestHeaders": {
+      "Content-Type": "application/json"
+    },
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "https://dataintegration.${SYS.REGION}.oci.oraclecloud.com/20200430/workspaces/${SYS.WORKSPACE_ID}/applications/${SYS.APPLICATION_KEY}/taskRuns?limit=1&sortOrder=DESC&sortBy=timeUpdated&aggregatorType=${TASK_TYPE}&nameStartsWith=${TASK_NAME}"
+        }
+      }
+    }
+  },
+  "apiCallMode": "SYNCHRONOUS",
+  "authConfig": {
+    "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+    "resourcePrincipalSource": "WORKSPACE"
+  },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }
+}

--- a/tasks/src/tasks/dataintegration/executetask.json
+++ b/tasks/src/tasks/dataintegration/executetask.json
@@ -1,0 +1,75 @@
+{
+    "modelType": "REST_TASK",
+    "name": "Execute Task",
+    "description": "Execute a task using its task key from the current application and workspace. This is a fire and forget task. The task must be in the same application that this task is deployed into (since the system parameter application key is used). ",
+    "identifier": "EXECUTE_TASK",
+    "parameters": [
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "",
+            "defaultValue": "taskKey",
+            "isInput": true,
+            "isOutput": false,
+            "name": "TASK_KEY",
+            "typeName": "VARCHAR"
+        }
+    ],
+    "opConfigValues": {
+        "configParamValues": {
+            "successCondition": {
+                "refValue": {
+                    "modelType": "EXPRESSION",
+                    "exprString": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS < 300"
+                }
+            }
+        }
+    },
+    "isConcurrentAllowed": true,
+    "executeRestCallConfig": {
+        "modelType": "REST_CALL_CONFIG",
+        "methodType": "POST",
+        "requestHeaders": {
+            "Content-Type": "application/json"
+        },
+        "configValues": {
+            "configParamValues": {
+                "requestURL": {
+                    "stringValue": "https://dataintegration.${SYS.REGION}.oci.oraclecloud.com/20200430/workspaces/${SYS.WORKSPACE_ID}/applications/${SYS.APPLICATION_KEY}/taskRuns"
+                },
+                "requestPayload": {
+                    "refValue": {
+                        "modelType": "JSON_TEXT",
+                        "encoded": false,
+                        "configValues": {
+                            "configParamValues": {
+                                "dataParam": {
+                                    "stringValue": "{\n  \"registryMetadata\": {\n    \"aggregatorKey\": \"${TASK_KEY}\"\n  }\n}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "apiCallMode": "SYNCHRONOUS",
+    "authConfig": {
+        "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+        "resourcePrincipalSource": "WORKSPACE"
+    },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }         
+
+}

--- a/tasks/src/tasks/dataintegration/executetaskandwait.json
+++ b/tasks/src/tasks/dataintegration/executetaskandwait.json
@@ -1,0 +1,137 @@
+{
+    "modelType": "REST_TASK",
+    "name": "Execute Task and Wait",
+    "description": "Get a task using its name and type from the current application and workspace. The task must be in the same application that this task is deployed into (since the system parameter application key is used). ",
+    "identifier": "EXECUTE_TASK_AND_WAIT",
+    "parameters": [
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload)"
+                    }
+                }
+            },
+            "description": "",
+            "defaultValue": "taskKey",
+            "isInput": true,
+            "isOutput": false,
+            "name": "TASK_KEY",
+            "typeName": "VARCHAR"
+        }
+    ],
+    "opConfigValues": {
+        "configParamValues": {
+            "successCondition": {
+                "refValue": {
+                    "modelType": "EXPRESSION",
+                    "exprString": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS < 300 AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.status') AS String) == 'SUCCESS'"
+                }
+            }
+        }
+    },
+    "isConcurrentAllowed": true,
+    "executeRestCallConfig": {
+        "modelType": "REST_CALL_CONFIG",
+        "key": "79c7a56c-9c20-4261-a4d7-ed714c21e5d7",
+        "methodType": "POST",
+        "requestHeaders": {
+            "Content-Type": "application/json"
+        },
+        "configValues": {
+            "configParamValues": {
+                "requestURL": {
+                    "stringValue": "https://dataintegration.${SYS.REGION}.oci.oraclecloud.com/20200430/workspaces/${SYS.WORKSPACE_ID}/applications/${SYS.APPLICATION_KEY}/taskRuns"
+                },
+                "requestPayload": {
+                    "refValue": {
+                        "modelType": "JSON_TEXT",
+                        "key": "ce425302-cf45-45b7-9705-be92aa4b4fc9",
+                        "parentRef": {
+                            "parent": "79c7a56c-9c20-4261-a4d7-ed714c21e5d7"
+                        },
+                        "encoded": false,
+                        "configValues": {
+                            "configParamValues": {
+                                "dataParam": {
+                                    "stringValue": "{\n  \"registryMetadata\": {\n    \"aggregatorKey\": \"${TASK_KEY}\"\n  }\n}"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "cancelRestCallConfig": {
+        "modelType": "REST_CALL_CONFIG",
+        "methodType": "DELETE"
+    },
+    "pollRestCallConfig": {
+        "modelType": "POLL_REST_CALL_CONFIG",
+        "methodType": "GET",
+        "configValues": {
+            "configParamValues": {
+                "pollMaxDuration": {
+                    "objectValue": 120
+                },
+                "pollMaxDurationUnit": {
+                    "stringValue": "SECONDS"
+                },
+                "pollInterval": {
+                    "objectValue": 60
+                },
+                "pollIntervalUnit": {
+                    "stringValue": "SECONDS"
+                },
+                "pollCondition": {
+                    "refValue": {
+                        "modelType": "EXPRESSION",
+                        "key": "88fb64ca-9dfe-45f3-82ea-55efb83ed51f",
+                        "parentRef": {
+                            "parent": "9497e5b6-b863-4a34-8dea-410baf92ae62"
+                        },
+                        "exprString": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.status') AS String) != 'SUCCESS' AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.status') AS String) != 'ERROR' AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.status') AS String) != 'TERMINATED'",
+                        "configValues": {
+                            "parentRef": {
+                                "parent": "88fb64ca-9dfe-45f3-82ea-55efb83ed51f"
+                            }
+                        }
+                    }
+                },
+                "requestURL": {
+                    "stringValue": "https://dataintegration.${SYS.REGION}.oci.oraclecloud.com/20200430/workspaces/${SYS.WORKSPACE_ID}/applications/${SYS.APPLICATION_KEY}/taskRuns/#{ID}"
+                }
+            }
+        }
+    },
+    "typedExpressions": [
+        {
+            "modelType": "TYPED_EXPRESSION",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 2000
+                    }
+                }
+            },
+            "expression": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.key') AS String)",
+            "name": "ID"
+        }
+    ],
+    "apiCallMode": "ASYNC_GENERIC",
+    "authConfig": {
+        "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+        "resourcePrincipalSource": "WORKSPACE"
+    },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }         
+
+}

--- a/tasks/src/tasks/dataintegration/gettask.json
+++ b/tasks/src/tasks/dataintegration/gettask.json
@@ -1,0 +1,83 @@
+{
+    "modelType": "REST_TASK",
+    "name": "Get Task",
+    "description": "Get a task using its name and type from the current application and workspace. The task must be in the same application that this task is deployed into (since the system parameter application key is used). ",
+    "identifier": "GET_TASK",
+    "parameters": [
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request URL)"
+                    }
+                }
+            },
+            "description": "Task type, one of INTEGRATION_TASK, DATA_LOADER_TASK, REST_TASK, PIPELINE_TASK, SQL_TASK",
+            "defaultValue": "INTEGRATION_TASK",
+            "isInput": true,
+            "isOutput": false,
+            "name": "TASK_TYPE",
+            "typeName": "STRING"
+        },
+        {
+            "modelType": "PARAMETER",
+            "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+            "configValues": {
+                "configParamValues": {
+                    "length": {
+                        "intValue": 255
+                    },
+                    "usedInParam": {
+                        "stringValue": "Execute API Config: (Request URL)"
+                    }
+                }
+            },
+            "description": "The task name, task runs will be listed using name query parameter",
+            "defaultValue": "ParamDemo_Task",
+            "isInput": true,
+            "isOutput": false,
+            "name": "TASK_NAME",
+            "typeName": "STRING"
+        }
+    ],
+    "opConfigValues": {
+        "configParamValues": {
+            "successCondition": {
+                "refValue": {
+                    "modelType": "EXPRESSION",
+                    "exprString": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS < 300"
+                }
+            }
+        }
+    },
+    "isConcurrentAllowed": true,
+    "executeRestCallConfig": {
+        "modelType": "REST_CALL_CONFIG",
+        "methodType": "GET",
+        "requestHeaders": {
+            "Content-Type": "application/json"
+        },
+        "configValues": {
+            "configParamValues": {
+                "requestURL": {
+                    "stringValue": "https://dataintegration.${SYS.REGION}.oci.oraclecloud.com/20200430/workspaces/${SYS.WORKSPACE_ID}/applications/${SYS.APPLICATION_KEY}/publishedObjects?limit=1&sortOrder=DESC&sortBy=timeUpdated&aggregatorType=${TASK_TYPE}&name=${TASK_NAME}"
+                }
+            }
+        }
+    },
+    "typedExpressions": [],
+    "apiCallMode": "SYNCHRONOUS",
+    "authConfig": {
+        "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+        "resourcePrincipalSource": "WORKSPACE"
+    },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }   
+
+}

--- a/tasks/src/tasks/datascience/datasciencejob.json
+++ b/tasks/src/tasks/datascience/datasciencejob.json
@@ -1,0 +1,259 @@
+{
+  "modelType": "REST_TASK",
+  "name": "Execute Data Science Job",
+  "description": "Execute Data Science Job and wait for it to complete.",
+  "identifier": "EXECUTE_DATA_SCIENCE_JOB",
+  "parameters": [
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL),Polling API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "us-ashburn-1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "REGION",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Data Science project id.",
+      "defaultValue": "enter_project_ocid",
+      "isInput": true,
+      "isOutput": false,
+      "name": "PROJECT_ID",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Data Science job id.",
+      "defaultValue": "enter_job_id",
+      "isInput": true,
+      "isOutput": false,
+      "name": "JOB_ID",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Compartment id to create run.",
+      "defaultValue": "enter_compartment_id",
+      "isInput": true,
+      "isOutput": false,
+      "name": "COMPARTMENT_ID",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Data Science job name.",
+      "defaultValue": "MyJob",
+      "isInput": true,
+      "isOutput": false,
+      "name": "JOB_NAME",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Command line args",
+      "defaultValue": " ",
+      "isInput": true,
+      "isOutput": false,
+      "name": "COMMAND_LINE_ARGS",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Maximum runtime",
+      "defaultValue": "1200",
+      "isInput": true,
+      "isOutput": false,
+      "name": "MAXIMUM_RUNTIME",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Environment variables",
+      "defaultValue": " ",
+      "isInput": true,
+      "isOutput": false,
+      "name": "ENVIRONMENT_VARS",
+      "typeName": "VARCHAR"
+    }
+  ],
+  "opConfigValues": {
+    "configParamValues": {
+      "successCondition": {
+        "refValue": {
+          "modelType": "EXPRESSION",
+          "exprString": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS <= 300 AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) == 'SUCCEEDED'"
+          }
+        }
+      }
+  },
+  "executeRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "POST",
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "https://datascience.${REGION}.oci.oraclecloud.com/20190101/jobRuns"
+        },
+        "requestPayload": {
+          "refValue": {
+            "modelType": "JSON_TEXT",
+            "encoded": false,
+            "configValues": {
+              "configParamValues": {
+                "dataParam": {
+                  "stringValue": "{\n  \"projectId\": \"${PROJECT_ID}\",\n  \"jobConfigurationOverrideDetails\": {\n    \"commandLineArguments\": \"${COMMAND_LINE_ARGS}\",\n    \"maximumRuntimeInMinutes\": \"${MAXIMUM_RUNTIME}\",\n    \"environmentVariables\": { ${ENVIRONMENT_VARS} },\n\t  \"jobType\": \"DEFAULT\"\n  },\n  \"jobId\": \"${JOB_ID}\",\n  \"compartmentId\": \"${COMPARTMENT_ID}\",\n  \"displayName\": \"${JOB_NAME}\",\n  \"freeformTags\": {},\n  \"definedTags\": {},\n  \"jobLogConfigurationOverrideDetails\": null\n}\n"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "cancelRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "DELETE"
+  },
+  "pollRestCallConfig": {
+    "modelType": "POLL_REST_CALL_CONFIG",
+    "methodType": "GET",
+    "configValues": {
+      "configParamValues": {
+        "pollMaxDuration": {
+          "objectValue": 1200
+        },
+        "pollMaxDurationUnit": {
+          "stringValue": "SECONDS"
+        },
+        "pollInterval": {
+          "objectValue": 60
+        },
+        "pollIntervalUnit": {
+          "stringValue": "SECONDS"
+        },
+        "requestURL": {
+          "stringValue": "https://datascience.${REGION}.oci.oraclecloud.com/20190101/jobRuns/#{JOB_RUN_ID}"
+        },
+        "pollCondition": {
+          "refValue": {
+            "modelType": "EXPRESSION",
+            "exprString": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'SUCCEEDED' AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'FAILED'"
+          }
+        }
+      }
+    }
+  },
+  "typedExpressions": [
+    {
+      "modelType": "TYPED_EXPRESSION",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 2000
+          }
+        },
+        "parentRef": {}
+      },
+      "expression": "json_path(SYS.RESPONSE_PAYLOAD_JSON, '$.id')",
+      "name": "JOB_RUN_ID"
+    }
+  ],
+  "apiCallMode": "ASYNC_GENERIC",
+  "authConfig": {
+    "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+    "resourcePrincipalSource": "WORKSPACE"
+  },
+    "registryMetadata": {
+        "aggregatorKey": "{{PROJECT_KEY}}"
+    }
+}

--- a/tasks/src/tasks/datascience/datasciencepipeline.json
+++ b/tasks/src/tasks/datascience/datasciencepipeline.json
@@ -1,0 +1,226 @@
+{
+  "modelType": "REST_TASK",
+  "name": "Execute Data Science Pipeline",
+  "description": "Run a pipeline job in OCI Data Science. See https://docs.oracle.com/en-us/iaas/api/#/en/data-science/20190101/PipelineRun/CreatePipelineRun",
+  "identifier": "EXECUTE_DATA_SCIENCE_PIPELINE",
+  "parameters": [
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL),Polling API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "OCI Region name.",
+      "defaultValue": "us-ashburn-1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "REGION",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Compartment to create container instance in.",
+      "defaultValue": "compartment_id",
+      "isInput": true,
+      "isOutput": false,
+      "name": "COMPARTMENT_ID",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Environment variables, specified as VAR:VAL, ...",
+      "defaultValue": " ",
+      "isInput": true,
+      "isOutput": false,
+      "name": "ENVIRONMENT_VARS",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Project id for Data Science pipeline.",
+      "defaultValue": "project_id",
+      "isInput": true,
+      "isOutput": false,
+      "name": "PROJECT_ID",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Pipeline id to run in Data Science.",
+      "defaultValue": "pipeline_id",
+      "isInput": true,
+      "isOutput": false,
+      "name": "PIPELINE_ID",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Display name for pipeline run.",
+      "defaultValue": "pipeline_run_job_name",
+      "isInput": true,
+      "isOutput": false,
+      "name": "DISPLAY_NAME",
+      "typeName": "VARCHAR"
+    }
+  ],
+  "opConfigValues": {
+    "configParamValues": {
+      "successCondition": {
+        "refValue": {
+          "modelType": "EXPRESSION",
+          "exprString": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS <= 300 AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) == 'SUCCEEDED'"
+          }
+        }
+      }
+  },
+  "executeRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "POST",
+    "configValues": {
+      "configParamValues": {
+        "requestPayload": {
+          "refValue": {
+            "modelType": "JSON_TEXT",
+            "encoded": false,
+            "configValues": {
+              "configParamValues": {
+                "dataParam": {
+                  "stringValue": "{\n  \"projectId\": \"${PROJECT_ID}\",\n  \"configurationOverrideDetails\": {\n    \"environmentVariables\": {\n\t\t\t${ENVIRONMENT_VARS}\n    },\n    \"type\": \"DEFAULT\"\n  },\n  \"pipelineId\": \"${PIPELINE_ID}\",\n  \"compartmentId\": \"${COMPARTMENT_ID}\",\n  \"displayName\": \"${DISPLAY_NAME}\",\n  \"freeformTags\": {},\n  \"definedTags\": {},\n  \"logConfigurationOverrideDetails\": null,\n  \"stepOverrideDetails\": []\n}\n"
+                }
+              }
+            }
+          }
+        },
+        "requestURL": {
+          "stringValue": "https://datascience.${REGION}.oci.oraclecloud.com/20190101/pipelineRuns"
+        }
+      }
+    }
+  },
+  "cancelRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "DELETE",
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "https://datascience.${REGION}.oci.oraclecloud.com/20190101/pipelineRuns/#{ID}"
+        }
+      }
+    }
+  },
+  "pollRestCallConfig": {
+    "modelType": "POLL_REST_CALL_CONFIG",
+    "methodType": "GET",
+    "configValues": {
+      "configParamValues": {
+        "pollMaxDuration": {
+          "objectValue": 1000
+        },
+        "pollMaxDurationUnit": {
+          "stringValue": "SECONDS"
+        },
+        "pollInterval": {
+          "objectValue": 60
+        },
+        "pollIntervalUnit": {
+          "stringValue": "SECONDS"
+        },
+        "requestURL": {
+          "stringValue": "https://datascience.${REGION}.oci.oraclecloud.com/20190101/pipelineRuns/#{ID}"
+        },
+        "pollCondition": {
+          "refValue": {
+            "modelType": "EXPRESSION",
+            "exprString": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'SUCCEEDED' AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'FAILED'"
+            }
+          }
+        }
+      }
+  },
+  "typedExpressions": [
+    {
+      "modelType": "TYPED_EXPRESSION",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 2000
+          }
+        }
+      },
+      "expression": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.id') AS String)",
+      "name": "ID"
+    }
+  ],
+  "apiCallMode": "ASYNC_GENERIC",
+  "authConfig": {
+    "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+    "resourcePrincipalSource": "WORKSPACE"
+  },
+  "registryMetadata": {
+        "aggregatorKey": "{{PROJECT_KEY}}"
+  }
+}
+

--- a/tasks/src/tasks/generic/execute.json
+++ b/tasks/src/tasks/generic/execute.json
@@ -1,0 +1,108 @@
+{
+  "modelType": "REST_TASK",
+  "name": "Execute OCI POST API",
+  "description": "Execute a POST REST API.",
+  "identifier": "EXECUTE_OCI_POST_API",
+  "parameters": [
+    {
+      "modelType": "PARAMETER",
+      "key": "04e2825d-8acb-4f5e-9b61-177a5c0ae1e5",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "http://abc",
+      "isInput": true,
+      "isOutput": false,
+      "name": "URL",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "key": "70c8b5f0-8b9f-4177-ad86-517a40b0de81",
+      "type": {
+        "modelType": "JAVA_TYPE",
+        "key": "04ee8b27-10e4-4493-8dda-9bf47aac9d47",
+        "parentRef": {
+          "parent": "70c8b5f0-8b9f-4177-ad86-517a40b0de81"
+        },
+        "javaTypeName": "com.oracle.dicom.model.dataformat.JsonText"
+      },
+      "configValues": {
+        "configParamValues": {
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload), Execute API Config: (Request Payload)"
+          }
+        },
+        "parentRef": {
+          "parent": "70c8b5f0-8b9f-4177-ad86-517a40b0de81"
+        }
+      },
+      "description": "POST API Request Body",
+      "isInput": true,
+      "isOutput": false,
+      "name": "REQUEST_BODY",
+      "rootObjectDefaultValue": {
+        "modelType": "JSON_TEXT",
+        "key": "442774d0-040e-4466-a282-a200e5269ec0",
+        "parentRef": {
+          "parent": "70c8b5f0-8b9f-4177-ad86-517a40b0de81"
+        },
+        "encoded": false,
+        "configValues": {
+          "configParamValues": {
+            "dataParam": {
+              "stringValue": "{}"
+            }
+          }
+        }
+      },
+      "typeName": "com.oracle.dicom.model.dataformat.JsonText"
+    }
+  ],
+  "opConfigValues": {
+    "configParamValues": {
+      "successCondition": {
+        "refValue": {
+          "modelType": "EXPRESSION",
+          "key": "c774bac7-4465-4953-a501-2cb8578aae62",
+          "exprString": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS < 300"
+        }
+      }
+    }
+  },
+  "executeRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "key": "cedde191-61fb-4bc2-9e47-c2c541233dd5",
+    "methodType": "POST",
+    "requestHeaders": {
+      "Content-Type": "application/json"
+    },
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "${URL}"
+        },
+        "requestPayload": {
+          "parameterValue": "70c8b5f0-8b9f-4177-ad86-517a40b0de81"
+        }
+      }
+    }
+  },
+  "apiCallMode": "SYNCHRONOUS",
+  "authConfig": {
+    "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+    "resourcePrincipalSource": "WORKSPACE"
+  },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }     
+}

--- a/tasks/src/tasks/generic/executeandpoll.json
+++ b/tasks/src/tasks/generic/executeandpoll.json
@@ -1,0 +1,219 @@
+{
+  "modelType": "REST_TASK",
+  "name": "Execute OCI POST API and Poll",
+  "description": "Execute a POST REST API. This fits a very specific OCI pattern for REST calls. One thing to note, is that the attribute used in the poll is hard-wired right now as the attribute id in the response.",
+  "identifier": "EXECUTE_OCI_POST_API_AND_POLL",
+  "parameters": [
+    {
+      "modelType": "PARAMETER",
+      "key": "e8ff9732-2a50-4dc8-8669-e21550d809e5",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "https://abc",
+      "isInput": true,
+      "isOutput": false,
+      "name": "URL",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "key": "14154173-021f-4f6b-92f8-0757e8543a45",
+      "type": {
+        "modelType": "JAVA_TYPE",
+        "key": "b5939c37-86a7-4687-b231-9512aa6eed70",
+        "parentRef": {
+          "parent": "14154173-021f-4f6b-92f8-0757e8543a45"
+        },
+        "javaTypeName": "com.oracle.dicom.model.dataformat.JsonText"
+      },
+      "configValues": {
+        "configParamValues": {
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        },
+        "parentRef": {
+          "parent": "14154173-021f-4f6b-92f8-0757e8543a45"
+        }
+      },
+      "description": "POST API Request Body",
+      "isInput": true,
+      "isOutput": false,
+      "name": "REQUEST_BODY",
+      "rootObjectDefaultValue": {
+        "modelType": "JSON_TEXT",
+        "key": "7010a758-e1e6-4ee4-b081-75744069bc2a",
+        "parentRef": {
+          "parent": "14154173-021f-4f6b-92f8-0757e8543a45"
+        },
+        "encoded": false,
+        "configValues": {
+          "configParamValues": {
+            "dataParam": {
+              "stringValue": "{}"
+            }
+          }
+        }
+      },
+      "typeName": "com.oracle.dicom.model.dataformat.JsonText"
+    },
+    {
+      "modelType": "PARAMETER",
+      "key": "60c01c60-d9c2-4ba5-92d8-4560b12812e9",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Polling API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "https://abc",
+      "isInput": true,
+      "isOutput": false,
+      "name": "POLL_URL",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "key": "e9000971-ce45-4423-874f-719293fe41c4",
+      "type": {
+        "modelType": "JAVA_TYPE",
+        "key": "9e655dc1-8525-4e50-8ed0-2db75681e473",
+        "parentRef": {
+          "parent": "e9000971-ce45-4423-874f-719293fe41c4"
+        },
+        "javaTypeName": "com.oracle.dicom.model.expression.Expression"
+      },
+      "configValues": {
+        "configParamValues": {
+          "usedInParam": {
+            "stringValue": "Success Condition"
+          }
+        },
+        "parentRef": {
+          "parent": "e9000971-ce45-4423-874f-719293fe41c4"
+        }
+      },
+      "description": "",
+      "defaultValue": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS < 300",
+      "isInput": true,
+      "isOutput": false,
+      "name": "SUCCESS_CONDITION",
+      "typeName": "com.oracle.dicom.model.expression.Expression"
+    },
+    {
+      "modelType": "PARAMETER",
+      "key": "5088c60a-f85c-4741-94e5-5edf8bb4f9a5",
+      "type": {
+        "modelType": "JAVA_TYPE",
+        "key": "9e655dc1-8525-4e50-8ed0-2db75681e473",
+        "parentRef": {
+          "parent": "e9000971-ce45-4423-874f-719293fe41c4"
+        },
+        "javaTypeName": "com.oracle.dicom.model.expression.Expression"
+      },
+      "description": "",
+      "defaultValue": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'SUCCEEDED' AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'FAILED'",
+      "isInput": true,
+      "isOutput": false,
+      "name": "POLL_CONDITION",
+      "typeName": "com.oracle.dicom.model.expression.Expression"
+    }
+  ],
+  "opConfigValues": {
+    "configParamValues": {
+      "successCondition": {
+        "parameterValue": "e9000971-ce45-4423-874f-719293fe41c4"
+      }
+    },
+    "parentRef": {}
+  },
+  "executeRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "key": "7b2af7c3-ca47-4724-ae6c-a20cf978d70f",
+    "methodType": "POST",
+    "requestHeaders": {
+      "Content-Type": "application/json"
+    },
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "${URL}"
+        },
+        "requestPayload": {
+          "parameterValue": "14154173-021f-4f6b-92f8-0757e8543a45"
+        }
+      }
+    }
+  },
+  "cancelRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "DELETE"
+  },
+  "pollRestCallConfig": {
+    "modelType": "POLL_REST_CALL_CONFIG",
+    "key": "3aa07d65-0ace-43ff-a59a-56e7bf0055fa",
+    "methodType": "GET",
+    "configValues": {
+      "configParamValues": {
+        "pollMaxDuration": {
+          "objectValue": 120
+        },
+        "pollMaxDurationUnit": {
+          "stringValue": "SECONDS"
+        },
+        "pollInterval": {
+          "objectValue": 60
+        },
+        "pollIntervalUnit": {
+          "stringValue": "SECONDS"
+        },
+        "requestURL": {
+          "stringValue": "${POLL_URL}"
+        },
+        "pollCondition": {
+          "parameterValue": "5088c60a-f85c-4741-94e5-5edf8bb4f9a5"
+        }
+      }
+    }
+  },
+  "typedExpressions": [
+    {
+      "modelType": "TYPED_EXPRESSION",
+      "key": "58565f8f-871a-4e75-ba69-ca1b30a9cfd6",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 2000
+          }
+        }
+      },
+      "expression": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.id') AS String)\t",
+      "name": "ID"
+    }
+  ],
+  "apiCallMode": "ASYNC_GENERIC",
+  "authConfig": {
+    "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+    "resourcePrincipalSource": "WORKSPACE"
+  },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }     
+}

--- a/tasks/src/tasks/monitoring/servicemetrics.json
+++ b/tasks/src/tasks/monitoring/servicemetrics.json
@@ -1,0 +1,173 @@
+{
+  "modelType": "REST_TASK",
+  "name": "ServiceMetricsTask",
+  "identifier": "SERVICEMETRICSTASK",
+  "parameters": [
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL), Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Region string for URL.",
+      "defaultValue": "us-ashburn-1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "REGION",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload), Execute API Config: (Request Payload)"
+          }
+        },
+        "parentRef": {}
+      },
+      "description": "Service namespace",
+      "defaultValue": "oci_autonomous_database",
+      "isInput": true,
+      "isOutput": false,
+      "name": "SERVICE_NAMESPACE",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload), Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "CpuUtilization[1m]{deploymentType = \\\"Shared\\\"}.mean()",
+      "isInput": true,
+      "isOutput": false,
+      "name": "QUERY",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload), Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "2022-12-16T16:19:00.000Z",
+      "isInput": true,
+      "isOutput": false,
+      "name": "END_TIME",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload), Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "2022-12-16T15:18:00.000Z",
+      "isInput": true,
+      "isOutput": false,
+      "name": "START_TIME",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Compartment id for metrics.",
+      "defaultValue": "compartmentid",
+      "isInput": true,
+      "isOutput": false,
+      "name": "COMPARTMENT_ID",
+      "typeName": "STRING"
+    }
+  ],
+  "opConfigValues": {
+    "configParamValues": {
+      "successCondition": {
+        "refValue": {
+          "modelType": "EXPRESSION",
+          "exprString": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS < 300"
+        }
+      }
+    }
+  },
+  "executeRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "POST",
+    "requestHeaders": {
+      "Content-Type": "application/json"
+    },
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "https://telemetry.${REGION}.oraclecloud.com/20180401/metrics/actions/summarizeMetricsData?compartmentId=${COMPARTMENT_ID}"
+        },
+        "requestPayload": {
+          "refValue": {
+            "modelType": "JSON_TEXT",
+            "encoded": false,
+            "configValues": {
+              "configParamValues": {
+                "dataParam": {
+                  "stringValue": "{\n  \"namespace\": \"${SERVICE_NAMESPACE}\",\n  \"query\": \"${QUERY}\",\n  \"endTime\": \"${END_TIME}\",\n  \"startTime\": \"${START_TIME}\"\n}"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "apiCallMode": "SYNCHRONOUS",
+  "authConfig": {
+    "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+    "resourcePrincipalSource": "WORKSPACE"
+  },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }
+}

--- a/tasks/src/tasks/nosql/createtable.json
+++ b/tasks/src/tasks/nosql/createtable.json
@@ -1,0 +1,133 @@
+{
+  "modelType": "REST_TASK",
+  "name": "Create Table in NoSQL",
+  "description": "Create a NoSQL table.",
+  "identifier": "CREATE_TABLE_IN_NOSQL",
+  "parameters": [
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Region string for URL.",
+      "defaultValue": "us-ashburn-1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "REGION",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Compartment id for metrics.",
+      "defaultValue": "compartmentid",
+      "isInput": true,
+      "isOutput": false,
+      "name": "COMPARTMENT_ID",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Table name.",
+      "defaultValue": "mytable",
+      "isInput": true,
+      "isOutput": false,
+      "name": "TABLE_NAME",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Table DDL",
+      "defaultValue": "CREATE TABLE mytable ( id INTEGER, body JSON, PRIMARY KEY ( id )) USING TTL 1 DAYS",
+      "isInput": true,
+      "isOutput": false,
+      "name": "TABLE_DDL",
+      "typeName": "VARCHAR"
+    }
+  ],
+  "opConfigValues": {
+    "configParamValues": {
+      "successCondition": {
+        "refValue": {
+          "modelType": "EXPRESSION",
+          "exprString": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS < 300"
+        }
+      }
+    }
+  },
+  "executeRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "POST",
+    "requestHeaders": {
+      "Content-Type": "application/json"
+    },
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "https://nosql.${REGION}.oci.oraclecloud.com/20190828/tables/"
+        },
+        "requestPayload": {
+          "refValue": {
+            "modelType": "JSON_TEXT",
+            "encoded": false,
+            "configValues": {
+              "configParamValues": {
+                "dataParam": {
+                  "stringValue": "{\n  \"name\": \"${TABLE_NAME}\",\n  \"compartmentId\": \"${COMPARTMENT_ID}\",\n  \"ddlStatement\": \"${TABLE_DDL}\",\n  \"tableLimits\": {\n    \"maxReadUnits\": 5,\n    \"maxWriteUnits\": 5,\n    \"maxStorageInGBs\": 1\n  },\n  \"freeformTags\": {\n    \"created_using\": \"OCI DI\"\n  }\n}"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "apiCallMode": "SYNCHRONOUS",
+  "authConfig": {
+    "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+    "resourcePrincipalSource": "WORKSPACE"
+  },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }
+}

--- a/tasks/src/tasks/nosql/deleterow.json
+++ b/tasks/src/tasks/nosql/deleterow.json
@@ -1,0 +1,153 @@
+{
+  "modelType": "REST_TASK",
+  "name": "Delete Row from NoSQL",
+  "description": "Delete a row from a NoSQL table.",
+  "identifier": "DELETE_ROW_FROM_NOSQL",
+  "parameters": [
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Region string for URL.",
+      "defaultValue": "us-ashburn-1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "REGION",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Compartment id for metrics.",
+      "defaultValue": "compartmentid",
+      "isInput": true,
+      "isOutput": false,
+      "name": "COMPARTMENT_ID",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Column name.",
+      "defaultValue": "id",
+      "isInput": true,
+      "isOutput": false,
+      "name": "COLUMN",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Column value.",
+      "defaultValue": "1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "VALUE",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Table name.",
+      "defaultValue": "mytable",
+      "isInput": true,
+      "isOutput": false,
+      "name": "TABLE_NAME",
+      "typeName": "STRING"
+    }
+  ],
+  "opConfigValues": {
+    "configParamValues": {
+      "successCondition": {
+        "refValue": {
+          "modelType": "EXPRESSION",
+          "exprString": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS < 300"
+        }
+      }
+    }
+  },
+  "executeRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "DELETE",
+    "requestHeaders": {
+      "Content-Type": "application/json"
+    },
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "https://nosql.${REGION}.oci.oraclecloud.com/20190828/tables/${TABLE_NAME}/rows?compartmentId=${COMPARTMENT_ID}&key=${COLUMN}:${VALUE}"
+        },
+        "requestPayload": {
+          "refValue": {
+            "modelType": "JSON_TEXT",
+            "encoded": false,
+            "configValues": {
+              "configParamValues": {
+                "dataParam": {
+                  "stringValue": ""
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "apiCallMode": "SYNCHRONOUS",
+  "authConfig": {
+    "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+    "resourcePrincipalSource": "WORKSPACE"
+  },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }
+}

--- a/tasks/src/tasks/nosql/getrow.json
+++ b/tasks/src/tasks/nosql/getrow.json
@@ -1,0 +1,153 @@
+{
+  "modelType": "REST_TASK",
+  "name": "Get Row from NoSQL",
+  "description": "Get a row from a NoSQL table.",
+  "identifier": "GET_ROW_FROM_NOSQL",
+  "parameters": [
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Region string for URL.",
+      "defaultValue": "us-ashburn-1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "REGION",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Compartment id for metrics.",
+      "defaultValue": "compartmentid",
+      "isInput": true,
+      "isOutput": false,
+      "name": "COMPARTMENT_ID",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Column name.",
+      "defaultValue": "id",
+      "isInput": true,
+      "isOutput": false,
+      "name": "COLUMN",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Column value.",
+      "defaultValue": "1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "VALUE",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Table name.",
+      "defaultValue": "mytable",
+      "isInput": true,
+      "isOutput": false,
+      "name": "TABLE_NAME",
+      "typeName": "STRING"
+    }
+  ],
+  "opConfigValues": {
+    "configParamValues": {
+      "successCondition": {
+        "refValue": {
+          "modelType": "EXPRESSION",
+          "exprString": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS < 300"
+        }
+      }
+    }
+  },
+ "executeRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "GET",
+    "requestHeaders": {
+      "Content-Type": "application/json"
+    },
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "https://nosql.${REGION}.oci.oraclecloud.com/20190828/tables/${TABLE_NAME}/rows?compartmentId=${COMPARTMENT_ID}&key=${COLUMN}:${VALUE}"
+        },
+        "requestPayload": {
+          "refValue": {
+            "modelType": "JSON_TEXT",
+            "encoded": false,
+            "configValues": {
+              "configParamValues": {
+                "dataParam": {
+                  "stringValue": ""
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "apiCallMode": "SYNCHRONOUS",
+  "authConfig": {
+    "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+    "resourcePrincipalSource": "WORKSPACE"
+  },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }
+}

--- a/tasks/src/tasks/nosql/updaterow.json
+++ b/tasks/src/tasks/nosql/updaterow.json
@@ -1,0 +1,133 @@
+{
+  "modelType": "REST_TASK",
+  "name": "Update Row in NoSQL",
+  "description": "Update a row in a NoSQL table.",
+  "identifier": "UPDATE_ROW_IN_NOSQL",
+  "parameters": [
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Region string for URL.",
+      "defaultValue": "us-ashburn-1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "REGION",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Compartment id for metrics.",
+      "defaultValue": "compartmentid",
+      "isInput": true,
+      "isOutput": false,
+      "name": "COMPARTMENT_ID",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Table name.",
+      "defaultValue": "mytable",
+      "isInput": true,
+      "isOutput": false,
+      "name": "TABLE_NAME",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "JSON string value",
+      "defaultValue": "{\"id\": \"1\",  \"data\": {\"taskName\": \"XYZ\"} }",
+      "isInput": true,
+      "isOutput": false,
+      "name": "JSON_STRING_VALUE",
+      "typeName": "VARCHAR"
+    }
+  ],
+  "opConfigValues": {
+    "configParamValues": {
+      "successCondition": {
+        "refValue": {
+          "modelType": "EXPRESSION",
+          "exprString": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS < 300"
+        }
+      }
+    }
+  },
+  "executeRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "PUT",
+    "requestHeaders": {
+      "Content-Type": "application/json"
+    },
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "https://nosql.${REGION}.oci.oraclecloud.com/20190828/tables/${TABLE_NAME}/rows"
+        },
+        "requestPayload": {
+          "refValue": {
+            "modelType": "JSON_TEXT",
+            "encoded": false,
+            "configValues": {
+              "configParamValues": {
+                "dataParam": {
+                  "stringValue": "{\n\t\"value\": ${JSON_STRING_VALUE},\n  \"compartmentId\": \"${COMPARTMENT_ID}\",\n  \"identityCacheSize\": 82616397,\n  \"isExactMatch\": false,\n  \"isGetReturnRow\": false,\n  \"isTtlUseTableDefault\": true,\n  \"option\": \"IF_PRESENT\",\n  \"timeoutInMs\": 5000,\n  \"ttl\": 96696908\n}"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "apiCallMode": "SYNCHRONOUS",
+  "authConfig": {
+    "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+    "resourcePrincipalSource": "WORKSPACE"
+  },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }
+}

--- a/tasks/src/tasks/nosql/waitondata.json
+++ b/tasks/src/tasks/nosql/waitondata.json
@@ -1,0 +1,226 @@
+{
+  "modelType": "REST_TASK",
+  "name": "Wait For Data from NoSQL",
+  "description": "Wait for data to be at a specific value in a NoSQL table and row. The table name, primary key identifier and JSON path and value are also provided. ",
+  "identifier": "WAIT_FOR_DATA_FROM_NOSQL",
+  "parameters": [
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Region string for URL.",
+      "defaultValue": "us-ashburn-1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "REGION",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Compartment id for metrics.",
+      "defaultValue": "compartmentid",
+      "isInput": true,
+      "isOutput": false,
+      "name": "COMPARTMENT_ID",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Column name.",
+      "defaultValue": "id",
+      "isInput": true,
+      "isOutput": false,
+      "name": "COLUMN",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Column value.",
+      "defaultValue": "1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "VALUE",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Table name.",
+      "defaultValue": "mytable",
+      "isInput": true,
+      "isOutput": false,
+      "name": "TABLE_NAME",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Polling API Config: (pollCondition),Success Condition"
+          }
+        }
+      },
+      "description": "The JSON path to a property to compare against the END_VALUE. ",
+      "defaultValue": "$.value.data.status",
+      "isInput": true,
+      "isOutput": false,
+      "name": "JSON_PATH_VARIABLE",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Polling API Config: (pollCondition),Success Condition"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "SUCCESS",
+      "isInput": true,
+      "isOutput": false,
+      "name": "END_VALUE",
+      "typeName": "VARCHAR"
+    }
+  ],
+  "opConfigValues": {
+    "configParamValues": {
+      "successCondition": {
+        "refValue": {
+          "modelType": "EXPRESSION",
+          "exprString": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS < 300 and JSON_PATH(SYS.RESPONSE_PAYLOAD, '${JSON_PATH_VARIABLE}') == '${END_VALUE}'"
+        }
+      }
+    }
+  },
+  "executeRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "GET",
+    "requestHeaders": {
+      "Content-Type": "application/json"
+    },
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "https://nosql.${REGION}.oci.oraclecloud.com/20190828/tables/${TABLE_NAME}/rows?compartmentId=${COMPARTMENT_ID}&key=${COLUMN}:${VALUE}"
+        },
+        "requestPayload": {
+          "refValue": {
+            "modelType": "JSON_TEXT",
+            "encoded": false,
+            "configValues": {
+              "configParamValues": {
+                "dataParam": {
+                  "stringValue": ""
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "cancelRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "DELETE"
+  },
+  "pollRestCallConfig": {
+    "modelType": "POLL_REST_CALL_CONFIG",
+    "methodType": "GET",
+    "configValues": {
+      "configParamValues": {
+        "pollMaxDuration": {
+          "objectValue": 8
+        },
+        "pollMaxDurationUnit": {
+          "stringValue": "HOURS"
+        },
+        "pollInterval": {
+          "objectValue": 60
+        },
+        "pollIntervalUnit": {
+          "stringValue": "SECONDS"
+        },
+        "requestURL": {
+          "stringValue": "https://nosql.${REGION}.oci.oraclecloud.com/20190828/tables/${TABLE_NAME}/rows?compartmentId=${COMPARTMENT_ID}&key=${COLUMN}:${VALUE}"
+        },
+        "pollCondition": {
+          "refValue": {
+            "modelType": "EXPRESSION",
+            "exprString": "JSON_PATH(SYS.RESPONSE_PAYLOAD, '${JSON_PATH_VARIABLE}') != '${END_VALUE}'"
+          }
+        }
+      }
+    }
+  },
+  "apiCallMode": "ASYNC_GENERIC",
+  "authConfig": {
+    "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+    "resourcePrincipalSource": "WORKSPACE"
+  },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }
+}

--- a/tasks/src/tasks/notification/notification.json
+++ b/tasks/src/tasks/notification/notification.json
@@ -1,0 +1,114 @@
+{
+  "modelType": "REST_TASK",
+  "key": "4a08b3ac-7704-4716-96b4-c82c349e2911",
+  "identifier": "PUBLISHNOTIFICATIONTASK",
+  "name": "PublishNotificationTask",
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  },
+  "opConfigValues": {
+    "configParamValues": {
+      "successCondition": {
+        "stringValue": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS < 300"
+      }
+    },
+    "parentRef": {}
+  },
+  "apiCallMode": "SYNCHRONOUS",
+  "authConfig": {
+    "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+    "resourcePrincipalSource": "WORKSPACE"
+  },
+  "executeRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "POST",
+    "requestHeaders": {
+      "Content-Type": "application/json"
+    },
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "https://notification.${REGION}.oci.oraclecloud.com/20181201/topics/${TOPICID}/messages"
+        },
+        "requestPayload": {
+          "parameterValue": "cee003fb-24e7-4da2-96cd-bbcab457cf00"
+        }
+      }
+    }
+  },
+  "parameters": [
+    {
+      "modelType": "PARAMETER",
+      "key": "311fa272-7fb6-42e3-adfc-38d019f44c3b",
+      "parentRef": {
+        "parent": "4a08b3ac-7704-4716-96b4-c82c349e2911"
+      },
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL), Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "",
+      "isInput": true,
+      "isOutput": false,
+      "name": "TOPICID",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "key": "ef308c23-d4f1-4c28-9083-c8f93e0e4703",
+      "parentRef": {
+        "parent": "4a08b3ac-7704-4716-96b4-c82c349e2911"
+      },
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload), Execute API Config: (Request URL)"
+          }
+        },
+        "parentRef": {}
+      },
+      "description": "Region name.",
+      "defaultValue": "us-ashburn-1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "REGION",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "key": "cee003fb-24e7-4da2-96cd-bbcab457cf00",
+      "typeName": "com.oracle.dicom.model.dataformat.JsonText",
+      "name": "PAYLOAD_BODY",
+      "description": "",
+      "isInput": true,
+      "isOutput": false,
+      "rootObjectDefaultValue": {
+        "modelType": "JSON_TEXT",
+        "key": "b94bb882-2484-46d6-bc00-433d860a08f0",
+        "configValues": {
+          "configParamValues": {
+            "dataParam": {
+              "stringValue": "{\"title\": \"Put your title here\", \"body\": \"You can put email body here. Check out OCI Data Integration!\"}"
+            }
+          }
+        }
+      },
+      "type": {
+        "modelType": "JAVA_TYPE",
+        "javaTypeName": "com.oracle.dicom.model.dataformat.JsonText"
+      }
+    }
+  ]
+}

--- a/tasks/src/tasks/objectstorage/oscopyobject.json
+++ b/tasks/src/tasks/objectstorage/oscopyobject.json
@@ -1,0 +1,284 @@
+{
+  "modelType": "REST_TASK",
+  "name": "Object Storage Copy Task",
+  "description": "Copy objects across OCI Object Storage.",
+  "identifier": "OBJECTSTORAGECOPYTASK",
+  "parameters": [
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL), Execute API Config: (Request URL), Execute API Config: (Request URL), Execute API Config: (Request URL), Execute API Config: (Request URL), Execute API Config: (Request URL), Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "namespace",
+      "isInput": true,
+      "isOutput": false,
+      "name": "NAMESPACE",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "bucket_name",
+      "isInput": true,
+      "isOutput": false,
+      "name": "BUCKET",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload), Execute API Config: (Request URL), Execute API Config: (Request URL), Execute API Config: (Request URL), Execute API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Region name.",
+      "defaultValue": "us-ashburn-1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "REGION",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL), Execute API Config: (Request URL), Execute API Config: (Request URL), Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "",
+      "isInput": true,
+      "isOutput": false,
+      "name": "BUCKET_NAME",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Destination bucket.",
+      "defaultValue": "bucketname",
+      "isInput": true,
+      "isOutput": false,
+      "name": "DESTINATION_BUCKET",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Destination namespace.",
+      "defaultValue": "destinationnamespace",
+      "isInput": true,
+      "isOutput": false,
+      "name": "DESTINATION_NAMESPACE",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Destination object name.",
+      "defaultValue": "destinationobjectname",
+      "isInput": true,
+      "isOutput": false,
+      "name": "DESTINATION_OBJECT_NAME",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Destination region.",
+      "defaultValue": "us-ashburn-1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "DESTINATION_REGION",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "sourceobjectname",
+      "isInput": true,
+      "isOutput": false,
+      "name": "SOURCE_OBJECT_NAME",
+      "typeName": "VARCHAR"
+    }
+  ],
+  "opConfigValues": {
+    "configParamValues": {
+      "successCondition": {
+        "stringValue": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS < 300"
+      }
+    }
+  },
+  "executeRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "POST",
+    "requestHeaders": {
+      "Content-Type": "application/json"
+    },
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "https://objectstorage.${REGION}.oraclecloud.com/n/${NAMESPACE}/b/${BUCKET_NAME}/actions/copyObject"
+        },
+        "requestPayload": {
+          "refValue": {
+            "modelType": "JSON_TEXT",
+            "encoded": false,
+            "configValues": {
+              "configParamValues": {
+                "dataParam": {
+                  "stringValue": "{\n  \"destinationBucket\": \"${DESTINATION_BUCKET}\",\n  \"destinationNamespace\": \"${DESTINATION_NAMESPACE}\",\n  \"destinationObjectName\": \"${DESTINATION_OBJECT_NAME}\",\n  \"destinationRegion\": \"${DESTINATION_REGION}\",\n  \"sourceObjectName\": \"${SOURCE_OBJECT_NAME}\"\n}\n"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "cancelRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "DELETE"
+  },
+  "pollRestCallConfig": {
+    "modelType": "POLL_REST_CALL_CONFIG",
+    "methodType": "GET",
+    "configValues": {
+      "configParamValues": {
+        "pollMaxDuration": {
+          "objectValue": 600
+        },
+        "pollMaxDurationUnit": {
+          "stringValue": "SECONDS"
+        },
+        "pollInterval": {
+          "objectValue": 60
+        },
+        "pollIntervalUnit": {
+          "stringValue": "SECONDS"
+        },
+        "requestURL": {
+          "stringValue": "https://objectstorage.${REGION}.oraclecloud.com/workRequests/#{WORK_REQUEST_ID}"
+        },
+        "pollCondition": {
+          "refValue": {
+            "modelType": "EXPRESSION",
+            "exprString": "CAST(json_path(SYS.RESPONSE_HEADERS, '$.status') AS String) != 'COMPLETED' AND CAST(json_path(SYS.RESPONSE_HEADERS, '$.status') AS String) != 'FAILED'"
+          }
+        }
+      }
+    }
+  },
+  "typedExpressions": [
+    {
+      "modelType": "TYPED_EXPRESSION",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 2000
+          }
+        }
+      },
+      "expression": "CAST(json_path(SYS.RESPONSE_HEADERS, '$.opc-work-request-id[0]') AS String)",
+      "name": "WORK_REQUEST_ID"
+    }
+  ],
+  "apiCallMode": "ASYNC_GENERIC",
+  "authConfig": {
+    "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+    "resourcePrincipalSource": "WORKSPACE"
+  },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }
+}

--- a/tasks/src/tasks/objectstorage/oscreatepar.json
+++ b/tasks/src/tasks/objectstorage/oscreatepar.json
@@ -1,0 +1,261 @@
+{
+  "modelType": "REST_TASK",
+  "name": "AI Speech Task",
+  "description": "Analyze objects in OCI Object Storage and extract information from the speech documents.",
+  "identifier": "AISPEECHTASK",
+  "parameters": [
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL), Execute API Config: (Request URL),Polling API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Region name.",
+      "defaultValue": "us-ashburn-1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "REGION",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "[{\"type\":\"PROFANITY\",\"mode\":\"REMOVE\"}]",
+      "isInput": true,
+      "isOutput": false,
+      "name": "JOB_FILTERS",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Compartment id for job.",
+      "defaultValue": "compartmentid",
+      "isInput": true,
+      "isOutput": false,
+      "name": "COMPARTMENT_ID",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Display name for speech job.",
+      "defaultValue": "SpeechJob",
+      "isInput": true,
+      "isOutput": false,
+      "name": "DISPLAY_NAME",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Output namspace.",
+      "defaultValue": "namespacename",
+      "isInput": true,
+      "isOutput": false,
+      "name": "OUTPUT_NAMESPACE",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Output prefix for folder containing generated objects.",
+      "defaultValue": "speechout",
+      "isInput": true,
+      "isOutput": false,
+      "name": "OUTPUT_PREFIX",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Output bucket name.",
+      "defaultValue": "a_delta_archive",
+      "isInput": true,
+      "isOutput": false,
+      "name": "OUTPUT_BUCKET",
+      "typeName": "VARCHAR"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Input data, specify namespace, bucket name and object names.",
+      "defaultValue": "[{\"namespaceName\": \"namespacename\",\"bucketName\": \"a_delta_changes\",\"objectNames\": [\"the-poet.wav\"] } ]",
+      "isInput": true,
+      "isOutput": false,
+      "name": "INPUT_DATA",
+      "typeName": "VARCHAR"
+    }
+  ],
+  "opConfigValues": {
+    "configParamValues": {
+      "successCondition": {
+        "refValue": {
+          "modelType": "EXPRESSION",
+          "exprString": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS <= 300 AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) == 'SUCCEEDED'"
+        }
+      }
+    }
+  },
+  "executeRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "POST",
+    "requestHeaders": {
+      "Content-Type": "application/json"
+    },
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "https://speech.aiservice.${REGION}.oci.oraclecloud.com/20220101/transcriptionJobs"
+        },
+        "requestPayload": {
+          "refValue": {
+            "modelType": "JSON_TEXT",
+            "encoded": false,
+            "configValues": {
+              "configParamValues": {
+                "dataParam": {
+                  "stringValue": "{  \"normalization\": {\"filters\": ${JOB_FILTERS},    \"isPunctuationEnabled\": true  },  \"compartmentId\": \"${COMPARTMENT_ID}\",  \"displayName\": \"${DISPLAY_NAME}\",  \"freeformTags\": {},  \"definedTags\": {},  \"modelDetails\": {    \"domain\": \"GENERIC\",    \"languageCode\": \"en-US\"  },  \"inputLocation\": {    \"locationType\": \"OBJECT_LIST_INLINE_INPUT_LOCATION\",    \"objectLocations\": ${INPUT_DATA}  },  \"outputLocation\": {    \"namespaceName\": \"${OUTPUT_NAMESPACE}\",    \"bucketName\": \"${OUTPUT_BUCKET}\",    \"prefix\": \"${OUTPUT_PREFIX}\"  },  \"additionalTranscriptionFormats\": null}"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "cancelRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "DELETE"
+  },
+  "pollRestCallConfig": {
+    "modelType": "POLL_REST_CALL_CONFIG",
+    "methodType": "GET",
+    "configValues": {
+      "configParamValues": {
+        "pollMaxDuration": {
+          "objectValue": 600
+        },
+        "pollMaxDurationUnit": {
+          "stringValue": "SECONDS"
+        },
+        "pollInterval": {
+          "objectValue": 60
+        },
+        "pollIntervalUnit": {
+          "stringValue": "SECONDS"
+        },
+        "requestURL": {
+          "stringValue": "https://speech.aiservice.${REGION}.oci.oraclecloud.com/20220101/transcriptionJobs/#{SPEECH_JOB_OCID}"
+        },
+        "pollCondition": {
+          "refValue": {
+            "modelType": "EXPRESSION",
+            "exprString": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'SUCCEEDED' AND CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.lifecycleState') AS String) != 'FAILED'"
+          }
+        }
+      }
+    }
+  },
+  "typedExpressions": [
+    {
+      "modelType": "TYPED_EXPRESSION",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/VARCHAR",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 2000
+          }
+        }
+      },
+      "expression": "CAST(json_path(SYS.RESPONSE_PAYLOAD, '$.id') AS String)",
+      "name": "SPEECH_JOB_OCID"
+    }
+  ],
+  "apiCallMode": "ASYNC_GENERIC",
+  "authConfig": {
+    "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+    "resourcePrincipalSource": "WORKSPACE"
+  },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }
+}

--- a/tasks/src/tasks/objectstorage/osdeleteobject.json
+++ b/tasks/src/tasks/objectstorage/osdeleteobject.json
@@ -1,0 +1,152 @@
+{
+  "modelType": "REST_TASK",
+  "identifier": "OBJECTSTORAGEDELETEOBJECTTASK",
+  "name": "Object Storage Delete Object Task",
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  },
+  "opConfigValues": {
+    "configParamValues": {
+      "successCondition": {
+        "stringValue": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS < 300"
+      }
+    }
+  },
+  "apiCallMode": "SYNCHRONOUS",
+  "authConfig": {
+    "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+    "resourcePrincipalSource": "WORKSPACE"
+  },
+  "executeRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "DELETE",
+    "requestHeaders": {
+      "Content-Type": "application/json"
+    },
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "https://objectstorage.${REGION}.oraclecloud.com/n/${NAMESPACE}/b/${BUCKET_NAME}/o/${OBJECT_NAME}"
+        },
+        "requestPayload": {
+          "refValue": {
+            "modelType": "JSON_TEXT",
+            "encoded": false,
+            "configValues": {
+              "configParamValues": {
+                "dataParam": {
+                  "stringValue": "{\"newName\": \"${NEW_NAME}\", \"sourceName\": \"${SOURCE_NAME}\" }"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "parameters": [
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL), Execute API Config: (Request URL), Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "namespace",
+      "isInput": true,
+      "isOutput": false,
+      "name": "NAMESPACE",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "bucket_name",
+      "isInput": true,
+      "isOutput": false,
+      "name": "BUCKET",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload), Execute API Config: (Request URL), Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Region name.",
+      "defaultValue": "us-ashburn-1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "REGION",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "typeName": "STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": ""
+          }
+        }
+      },
+      "name": "BUCKET_NAME",
+      "description": "",
+      "isInput": true,
+      "isOutput": false,
+      "defaultValue": "bucketName"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "typeName": "STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": "4000"
+          },
+          "usedInParam": {
+            "stringValue": ""
+          }
+        }
+      },
+      "name": "OBJECT_NAME",
+      "description": "",
+      "isInput": true,
+      "isOutput": false,
+      "defaultValue": "objectName"
+    }
+  ]
+}

--- a/tasks/src/tasks/objectstorage/oslistobjects.json
+++ b/tasks/src/tasks/objectstorage/oslistobjects.json
@@ -1,0 +1,196 @@
+{
+  "modelType": "REST_TASK",
+  "name": "Object Storage List Objects Task",
+  "identifier": "OBJECTSTORAGELISTOBJECTSTASK",
+  "parameters": [
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL), Execute API Config: (Request URL), Execute API Config: (Request URL), Execute API Config: (Request URL), Execute API Config: (Request URL), Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "namespace",
+      "isInput": true,
+      "isOutput": false,
+      "name": "NAMESPACE",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "bucket_name",
+      "isInput": true,
+      "isOutput": false,
+      "name": "BUCKET",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Source name.",
+      "defaultValue": "source_object_name",
+      "isInput": true,
+      "isOutput": false,
+      "name": "SOURCE_NAME",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload), Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "New name.",
+      "defaultValue": "new_object_name",
+      "isInput": true,
+      "isOutput": false,
+      "name": "NEW_NAME",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload), Execute API Config: (Request URL), Execute API Config: (Request URL), Execute API Config: (Request URL), Execute API Config: (Request URL), Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "Region name.",
+      "defaultValue": "us-ashburn-1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "REGION",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL), Execute API Config: (Request URL), Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "bucketName",
+      "isInput": true,
+      "isOutput": false,
+      "name": "BUCKET_NAME",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 4000
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL), Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "objectName",
+      "isInput": true,
+      "isOutput": false,
+      "name": "OBJECT_NAME",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "",
+      "isInput": true,
+      "isOutput": false,
+      "name": "OBJECT_PREFIX",
+      "typeName": "STRING"
+    }
+  ],
+  "opConfigValues": {
+    "configParamValues": {
+      "successCondition": {
+        "stringValue": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS < 300"
+      }
+    }
+  },
+  "executeRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "GET",
+    "requestHeaders": {
+      "Content-Type": "application/json"
+    },
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "https://objectstorage.${REGION}.oraclecloud.com/n/${NAMESPACE}/b/${BUCKET_NAME}/o?prefix=${OBJECT_PREFIX}"
+        }
+      }
+    }
+  },
+  "apiCallMode": "SYNCHRONOUS",
+  "authConfig": {
+    "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+    "resourcePrincipalSource": "WORKSPACE"
+  },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}"
+  }
+}

--- a/tasks/src/tasks/objectstorage/osrenameobject.json
+++ b/tasks/src/tasks/objectstorage/osrenameobject.json
@@ -1,0 +1,151 @@
+{
+  "modelType": "REST_TASK",
+  "name": "Object Storage Rename Object Task",
+  "identifier": "OBJECTSTORAGERENAMEOBJECTTASK",
+  "parameters": [
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "namespace",
+      "isInput": true,
+      "isOutput": false,
+      "name": "NAMESPACE",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "length": {
+            "intValue": 255
+          },
+          "scale": {
+            "intValue": 0
+          },
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request URL)"
+          }
+        }
+      },
+      "description": "",
+      "defaultValue": "bucket_name",
+      "isInput": true,
+      "isOutput": false,
+      "name": "BUCKET",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Source name.",
+      "defaultValue": "source_object_name",
+      "isInput": true,
+      "isOutput": false,
+      "name": "SOURCE_NAME",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "New name.",
+      "defaultValue": "new_object_name",
+      "isInput": true,
+      "isOutput": false,
+      "name": "NEW_NAME",
+      "typeName": "STRING"
+    },
+    {
+      "modelType": "PARAMETER",
+      "type": "Seeded:/typeSystems/PLATFORM/dataTypes/STRING",
+      "configValues": {
+        "configParamValues": {
+          "usedInParam": {
+            "stringValue": "Execute API Config: (Request Payload)"
+          }
+        }
+      },
+      "description": "Region name.",
+      "defaultValue": "us-ashburn-1",
+      "isInput": true,
+      "isOutput": false,
+      "name": "REGION",
+      "typeName": "STRING"
+    }
+  ],
+  "opConfigValues": {
+    "configParamValues": {
+      "successCondition": {
+        "stringValue": "SYS.RESPONSE_STATUS >= 200 AND SYS.RESPONSE_STATUS < 300"
+      }
+    }
+  },
+  "executeRestCallConfig": {
+    "modelType": "REST_CALL_CONFIG",
+    "methodType": "POST",
+    "requestHeaders": {
+      "Content-Type": "application/json"
+    },
+    "configValues": {
+      "configParamValues": {
+        "requestURL": {
+          "stringValue": "https://objectstorage.${REGION}.oraclecloud.com/n/${NAMESPACE}/b/${BUCKET_NAME}/actions/renameObject"
+        },
+        "requestPayload": {
+          "refValue": {
+            "modelType": "JSON_TEXT",
+            "encoded": false,
+            "configValues": {
+              "configParamValues": {
+                "dataParam": {
+                  "stringValue": "{\"newName\": \"${NEW_NAME}\", \"sourceName\": \"${SOURCE_NAME}\" }"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "typedExpressions": [],
+  "apiCallMode": "SYNCHRONOUS",
+  "authDetails": {
+    "modelType": "RESOURCE_PRINCIPAL_AUTH_DETAILS"
+  },
+  "authConfig": {
+    "modelType": "OCI_RESOURCE_AUTH_CONFIG",
+    "resourcePrincipalSource": "WORKSPACE"
+  },
+  "registryMetadata": {
+    "aggregatorKey": "{{PROJECT_KEY}}",
+    "isFavorite": true
+  }
+}


### PR DESCRIPTION
Add REST Task examples to the DIS Samples. The tasks include common tasks from executing and checking task run state in Data Integration, to executing Spark jobs in OCI Dataflow, publishing notifications and many more. A shell script is provided to create the tasks in a project/workspace of the customer's choice.